### PR TITLE
feat: add response DTO, add join validation

### DIFF
--- a/src/main/java/com/example/comitserver/controller/JoinController.java
+++ b/src/main/java/com/example/comitserver/controller/JoinController.java
@@ -1,11 +1,11 @@
 package com.example.comitserver.controller;
 
 import com.example.comitserver.dto.JoinDTO;
-import com.example.comitserver.dto.ServerErrorDTO;
 import com.example.comitserver.dto.ServerResponseDTO;
 import com.example.comitserver.entity.UserEntity;
 import com.example.comitserver.exception.DuplicateResourceException;
 import com.example.comitserver.service.JoinService;
+import com.example.comitserver.uitls.ResponseUtil;
 import jakarta.validation.Valid;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
@@ -25,26 +25,16 @@ public class JoinController {
     @PostMapping("/join")
     public ResponseEntity<?> joinProcess(@RequestBody @Valid JoinDTO joinDTO) {
         UserEntity createdUser = joinService.joinProcess(joinDTO);
-
-        return new ResponseEntity<>(
-                new ServerResponseDTO(null,
-                        createdUser
-                ), HttpStatus.OK
-        );
+        return ResponseUtil.createSuccessResponse(createdUser);
     }
 
     @ExceptionHandler(DuplicateResourceException.class)
     public ResponseEntity<?> handleDuplicateResourceException(DuplicateResourceException ex) {
-        return new ResponseEntity<>(
-                new ServerResponseDTO(
-                        new ServerErrorDTO(
-                                "409 Conflict",
-                                "Duplicate Resource",
-                                ex.getMessage()
-                        ),
-                        null
-                ),
-                HttpStatus.CONFLICT
+        return ResponseUtil.createErrorResponse(
+                HttpStatus.CONFLICT,
+                "409 Conflict",
+                "Duplicate Resource",
+                ex.getMessage()
         );
     }
 
@@ -56,15 +46,11 @@ public class JoinController {
                 .map(DefaultMessageSourceResolvable::getDefaultMessage)
                 .orElse("Validation error");
 
-        ServerErrorDTO serverError = new ServerErrorDTO(
+        return ResponseUtil.createErrorResponse(
+                HttpStatus.BAD_REQUEST,
                 "400 Bad Request",
                 "Validation Failed",
                 errorMessage
-        );
-
-        return new ResponseEntity<>(
-                new ServerResponseDTO(serverError, null),
-                HttpStatus.BAD_REQUEST
         );
     }
 }

--- a/src/main/java/com/example/comitserver/controller/JoinController.java
+++ b/src/main/java/com/example/comitserver/controller/JoinController.java
@@ -25,7 +25,7 @@ public class JoinController {
     @PostMapping("/join")
     public ResponseEntity<?> joinProcess(@RequestBody @Valid JoinDTO joinDTO) {
         UserEntity createdUser = joinService.joinProcess(joinDTO);
-        return ResponseUtil.createSuccessResponse(createdUser);
+        return ResponseUtil.createSuccessResponse(createdUser, HttpStatus.CREATED);
     }
 
     @ExceptionHandler(DuplicateResourceException.class)

--- a/src/main/java/com/example/comitserver/controller/JoinController.java
+++ b/src/main/java/com/example/comitserver/controller/JoinController.java
@@ -1,16 +1,14 @@
 package com.example.comitserver.controller;
 
 import com.example.comitserver.dto.JoinDTO;
+import com.example.comitserver.dto.ServerErrorDTO;
+import com.example.comitserver.dto.ServerResponseDTO;
+import com.example.comitserver.entity.UserEntity;
+import com.example.comitserver.exception.DuplicateResourceException;
 import com.example.comitserver.service.JoinService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.util.HashMap;
-import java.util.Map;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api")
@@ -23,11 +21,29 @@ public class JoinController {
 
     @PostMapping("/join")
     public ResponseEntity<?> joinProcess(@RequestBody JoinDTO joinDTO) {
-        joinService.joinProcess(joinDTO);
+        UserEntity createdUser = joinService.joinProcess(joinDTO);
 
-        Map<String, String> responseBody = new HashMap<>();
-        responseBody.put("message", "Join Successful");
-
-        return new ResponseEntity<>(responseBody, HttpStatus.OK);
+        return new ResponseEntity<>(
+                new ServerResponseDTO(null,
+                        createdUser
+                ), HttpStatus.OK
+        );
     }
+
+    @ExceptionHandler(DuplicateResourceException.class)
+    public ResponseEntity<?> handleDuplicateResourceException(DuplicateResourceException ex) {
+        return new ResponseEntity<>(
+                new ServerResponseDTO(
+                        new ServerErrorDTO(
+                                "409 Conflict",
+                                "Duplicate Resource",
+                                ex.getMessage()
+                        ),
+                        null
+                ),
+                HttpStatus.CONFLICT
+        );
+    }
+
+    //TODO: validation 추가
 }

--- a/src/main/java/com/example/comitserver/controller/JoinController.java
+++ b/src/main/java/com/example/comitserver/controller/JoinController.java
@@ -32,8 +32,7 @@ public class JoinController {
     public ResponseEntity<?> handleDuplicateResourceException(DuplicateResourceException ex) {
         return ResponseUtil.createErrorResponse(
                 HttpStatus.CONFLICT,
-                "Conflict",
-                "Duplicate Resource",
+                "Join/DuplicateResource",
                 ex.getMessage()
         );
     }
@@ -48,8 +47,7 @@ public class JoinController {
 
         return ResponseUtil.createErrorResponse(
                 HttpStatus.BAD_REQUEST,
-                "Bad Request",
-                "Validation Failed",
+                "Join/ValidationFailed",
                 errorMessage
         );
     }

--- a/src/main/java/com/example/comitserver/controller/JoinController.java
+++ b/src/main/java/com/example/comitserver/controller/JoinController.java
@@ -32,7 +32,7 @@ public class JoinController {
     public ResponseEntity<?> handleDuplicateResourceException(DuplicateResourceException ex) {
         return ResponseUtil.createErrorResponse(
                 HttpStatus.CONFLICT,
-                "409 Conflict",
+                "Conflict",
                 "Duplicate Resource",
                 ex.getMessage()
         );
@@ -48,7 +48,7 @@ public class JoinController {
 
         return ResponseUtil.createErrorResponse(
                 HttpStatus.BAD_REQUEST,
-                "400 Bad Request",
+                "Bad Request",
                 "Validation Failed",
                 errorMessage
         );

--- a/src/main/java/com/example/comitserver/controller/ReissueController.java
+++ b/src/main/java/com/example/comitserver/controller/ReissueController.java
@@ -28,8 +28,7 @@ public class ReissueController {
         if (refresh == null) {
             return ResponseUtil.createErrorResponse(
                     HttpStatus.BAD_REQUEST,
-                    "Bad Request",
-                    "Refresh token missing",
+                    "Reissue/TokenMissing",
                     "The request is missing the required refresh token. Please include a valid refresh token in cookie."
             );
         }
@@ -37,8 +36,7 @@ public class ReissueController {
         if (reissueService.isTokenExpired(refresh)) {
             return ResponseUtil.createErrorResponse(
                     HttpStatus.UNAUTHORIZED,
-                    "401 Unauthorized",
-                    "Refresh token expired",
+                    "Reissue/TokenExpired",
                     "The provided refresh token has expired. Please request a new token or reauthenticate."
             );
         }
@@ -46,8 +44,7 @@ public class ReissueController {
         if (!reissueService.isValidRefreshToken(refresh)) {
             return ResponseUtil.createErrorResponse(
                     HttpStatus.UNAUTHORIZED,
-                    "401 Unauthorized",
-                    "Invalid refresh token",
+                    "Reissue/InvalidToken",
                     "The provided refresh token is invalid. Please provide a valid refresh token or reauthenticate."
             );
         }
@@ -55,8 +52,7 @@ public class ReissueController {
         if (!reissueService.existsInDatabase(refresh)) {
             return ResponseUtil.createErrorResponse(
                     HttpStatus.NOT_FOUND,
-                    "404 Not Found",
-                    "Invalid refresh token",
+                    "Reissue/TokenNotFound",
                     "The provided refresh token is invalid. Please provide a valid refresh token or reauthenticate."
             );
         }

--- a/src/main/java/com/example/comitserver/controller/ReissueController.java
+++ b/src/main/java/com/example/comitserver/controller/ReissueController.java
@@ -43,6 +43,11 @@ public class ReissueController {
             return new ResponseEntity<>("invalid refresh token", HttpStatus.BAD_REQUEST);
         }
 
+        //현재 로그인된 id와 토큰의 id를 비교
+        if (!reissueService.isUserIdValidForToken(refresh, reissueService.getCurrentUserId())) {
+            return new ResponseEntity<>("user ID mismatch", HttpStatus.BAD_REQUEST);
+        }
+
         Long userId = reissueService.getUserIdFromToken(refresh);
         String newAccess = reissueService.createAccessToken(userId);
         String newRefresh = reissueService.createRefreshToken(userId);

--- a/src/main/java/com/example/comitserver/controller/ReissueController.java
+++ b/src/main/java/com/example/comitserver/controller/ReissueController.java
@@ -1,9 +1,8 @@
 package com.example.comitserver.controller;
 
-import com.example.comitserver.dto.ServerErrorDTO;
-import com.example.comitserver.dto.ServerResponseDTO;
 import com.example.comitserver.jwt.JWTUtil;
 import com.example.comitserver.service.ReissueService;
+import com.example.comitserver.uitls.ResponseUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
@@ -11,9 +10,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api")
@@ -30,50 +26,38 @@ public class ReissueController {
         String refresh = reissueService.getRefreshTokenFromCookies(request);
 
         if (refresh == null) {
-            return new ResponseEntity<>(
-                    new ServerResponseDTO(
-                            new ServerErrorDTO(
-                                    "400 Bad Request",
-                                    "Refresh token missing",
-                                    "The request is missing the required refresh token. Please include a valid refresh token in cookie."
-                            ), null
-                    ), HttpStatus.BAD_REQUEST
+            return ResponseUtil.createErrorResponse(
+                    HttpStatus.BAD_REQUEST,
+                    "400 Bad Request",
+                    "Refresh token missing",
+                    "The request is missing the required refresh token. Please include a valid refresh token in cookie."
             );
         }
 
         if (reissueService.isTokenExpired(refresh)) {
-            return new ResponseEntity<>(
-                    new ServerResponseDTO(
-                            new ServerErrorDTO(
-                                    "401 Unauthorized",
-                                    "Refresh token expired",
-                                    "The provided refresh token has expired. Please request a new token or reauthenticate."
-                            ), null
-                    ), HttpStatus.UNAUTHORIZED
+            return ResponseUtil.createErrorResponse(
+                    HttpStatus.UNAUTHORIZED,
+                    "401 Unauthorized",
+                    "Refresh token expired",
+                    "The provided refresh token has expired. Please request a new token or reauthenticate."
             );
         }
 
         if (!reissueService.isValidRefreshToken(refresh)) {
-            return new ResponseEntity<>(
-                    new ServerResponseDTO(
-                            new ServerErrorDTO(
-                                    "401 Unauthorized",
-                                    "Invalid refresh token",
-                                    "The provided refresh token is invalid. Please provide a valid refresh token or reauthenticate."
-                            ), null
-                    ), HttpStatus.UNAUTHORIZED
+            return ResponseUtil.createErrorResponse(
+                    HttpStatus.UNAUTHORIZED,
+                    "401 Unauthorized",
+                    "Invalid refresh token",
+                    "The provided refresh token is invalid. Please provide a valid refresh token or reauthenticate."
             );
         }
 
         if (!reissueService.existsInDatabase(refresh)) {
-            return new ResponseEntity<>(
-                    new ServerResponseDTO(
-                            new ServerErrorDTO(
-                                    "404 Not Found",
-                                    "Invalid refresh token",
-                                    "The provided refresh token is invalid. Please provide a valid refresh token or reauthenticate."
-                            ), null
-                    ), HttpStatus.NOT_FOUND
+            return ResponseUtil.createErrorResponse(
+                    HttpStatus.NOT_FOUND,
+                    "404 Not Found",
+                    "Invalid refresh token",
+                    "The provided refresh token is invalid. Please provide a valid refresh token or reauthenticate."
             );
         }
 
@@ -86,9 +70,6 @@ public class ReissueController {
         response.setHeader("access", newAccess);
         response.addCookie(JWTUtil.createCookie("refresh", newRefresh));
 
-        Map<String, String> responseBody = new HashMap<>();
-        responseBody.put("message", "Reissue Successful");
-
-        return new ResponseEntity<>(responseBody, HttpStatus.OK);
+        return ResponseUtil.createSuccessResponse(null);
     }
 }

--- a/src/main/java/com/example/comitserver/controller/ReissueController.java
+++ b/src/main/java/com/example/comitserver/controller/ReissueController.java
@@ -28,7 +28,7 @@ public class ReissueController {
         if (refresh == null) {
             return ResponseUtil.createErrorResponse(
                     HttpStatus.BAD_REQUEST,
-                    "400 Bad Request",
+                    "Bad Request",
                     "Refresh token missing",
                     "The request is missing the required refresh token. Please include a valid refresh token in cookie."
             );

--- a/src/main/java/com/example/comitserver/controller/ReissueController.java
+++ b/src/main/java/com/example/comitserver/controller/ReissueController.java
@@ -66,6 +66,6 @@ public class ReissueController {
         response.setHeader("access", newAccess);
         response.addCookie(JWTUtil.createCookie("refresh", newRefresh));
 
-        return ResponseUtil.createSuccessResponse(null);
+        return ResponseUtil.createSuccessResponse(null, HttpStatus.CREATED);
     }
 }

--- a/src/main/java/com/example/comitserver/dto/JoinDTO.java
+++ b/src/main/java/com/example/comitserver/dto/JoinDTO.java
@@ -1,12 +1,29 @@
 package com.example.comitserver.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
 public class JoinDTO {
+    @NotBlank(message = "Username is required.")
     private String username;
+
+    @NotBlank(message = "Password is required.")
+    @Size(min = 6, message = "Password must be at least 6 characters long.")
     private String password;
+
+    @NotBlank(message = "Phone number is required.")
+    @Pattern(regexp = "\\d+", message = "Phone number must contain only digits.")
     private String phoneNumber;
+
+    @NotBlank(message = "Student ID is required.")
+    @Pattern(regexp = "\\d{10}", message = "Student ID must be exactly 10 digits long.")
     private String studentId;
+
+    @NotBlank(message = "Email is required.")
+    @Email(message = "Please enter a valid email address.")
     private String email;
 }

--- a/src/main/java/com/example/comitserver/dto/ServerErrorDTO.java
+++ b/src/main/java/com/example/comitserver/dto/ServerErrorDTO.java
@@ -5,12 +5,10 @@ import lombok.Data;
 @Data
 public class ServerErrorDTO {
     private String errorType;
-    private String title;
     private String detail;
 
-    public ServerErrorDTO(String errorType, String title, String detail) {
+    public ServerErrorDTO(String errorType, String detail) {
         this.errorType = errorType;
-        this.title = title;
         this.detail = detail;
     }
 }

--- a/src/main/java/com/example/comitserver/dto/ServerErrorDTO.java
+++ b/src/main/java/com/example/comitserver/dto/ServerErrorDTO.java
@@ -1,0 +1,16 @@
+package com.example.comitserver.dto;
+
+import lombok.Data;
+
+@Data
+public class ServerErrorDTO {
+    private String errorType;
+    private String title;
+    private String detail;
+
+    public ServerErrorDTO(String errorType, String title, String detail) {
+        this.errorType = errorType;
+        this.title = title;
+        this.detail = detail;
+    }
+}

--- a/src/main/java/com/example/comitserver/dto/ServerResponseDTO.java
+++ b/src/main/java/com/example/comitserver/dto/ServerResponseDTO.java
@@ -1,0 +1,17 @@
+package com.example.comitserver.dto;
+
+import lombok.Data;
+
+import java.util.Optional;
+
+@Data
+public class ServerResponseDTO {
+    private Optional<ServerErrorDTO> error;
+    private Object data;
+
+    public ServerResponseDTO(ServerErrorDTO error, Object data) {
+        this.error = Optional.ofNullable(error);
+        this.data = data;
+    }
+}
+

--- a/src/main/java/com/example/comitserver/exception/DuplicateResourceException.java
+++ b/src/main/java/com/example/comitserver/exception/DuplicateResourceException.java
@@ -1,0 +1,7 @@
+package com.example.comitserver.exception;
+
+public class DuplicateResourceException extends RuntimeException {
+    public DuplicateResourceException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/comitserver/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/example/comitserver/jwt/CustomLogoutFilter.java
@@ -58,7 +58,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
             ResponseUtil.writeErrorResponse(
                     response,
                     HttpStatus.BAD_REQUEST,
-                    "400 Bad Request",
+                    "Bad Request",
                     "Logout Failed",
                     "Refresh token is missing. Please provide a valid refresh token."
             );
@@ -71,8 +71,8 @@ public class CustomLogoutFilter extends GenericFilterBean {
         } catch (ExpiredJwtException e) {
             ResponseUtil.writeErrorResponse(
                     response,
-                    HttpStatus.BAD_REQUEST,
-                    "400 Bad Request",
+                    HttpStatus.UNAUTHORIZED,
+                    "Unauthorized",
                     "Logout Failed",
                     "Refresh token has expired. Please provide a valid refresh token."
             );
@@ -85,7 +85,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
             ResponseUtil.writeErrorResponse(
                     response,
                     HttpStatus.BAD_REQUEST,
-                    "400 Bad Request",
+                    "Bad Request",
                     "Logout Failed",
                     "Invalid token type. Expected a refresh token."
             );
@@ -97,8 +97,8 @@ public class CustomLogoutFilter extends GenericFilterBean {
         if (!isExist) {
             ResponseUtil.writeErrorResponse(
                     response,
-                    HttpStatus.BAD_REQUEST,
-                    "400 Bad Request",
+                    HttpStatus.NOT_FOUND,
+                    "Not Found",
                     "Logout Failed",
                     "Refresh token not found in the database. Please log in again."
             );

--- a/src/main/java/com/example/comitserver/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/example/comitserver/jwt/CustomLogoutFilter.java
@@ -1,8 +1,7 @@
 package com.example.comitserver.jwt;
 
-import com.example.comitserver.dto.ServerErrorDTO;
 import com.example.comitserver.repository.RefreshRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.example.comitserver.uitls.ResponseUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -11,17 +10,14 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.filter.GenericFilterBean;
 
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.HashMap;
-import java.util.Map;
 
 public class CustomLogoutFilter extends GenericFilterBean {
     private final JWTUtil jwtUtil;
     private final RefreshRepository refreshRepository;
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     public CustomLogoutFilter(JWTUtil jwtUtil, RefreshRepository refreshRepository) {
         this.jwtUtil = jwtUtil;
@@ -59,7 +55,13 @@ public class CustomLogoutFilter extends GenericFilterBean {
 
         // Handle missing refresh token
         if (refresh == null) {
-            writeErrorResponse(response, "Refresh token is missing. Please provide a valid refresh token.");
+            ResponseUtil.writeErrorResponse(
+                    response,
+                    HttpStatus.BAD_REQUEST,
+                    "400 Bad Request",
+                    "Logout Failed",
+                    "Refresh token is missing. Please provide a valid refresh token."
+            );
             return;
         }
 
@@ -67,26 +69,41 @@ public class CustomLogoutFilter extends GenericFilterBean {
         try {
             jwtUtil.isExpired(refresh);
         } catch (ExpiredJwtException e) {
-            writeErrorResponse(response, "Refresh token has expired. Please provide a valid refresh token.");
+            ResponseUtil.writeErrorResponse(
+                    response,
+                    HttpStatus.BAD_REQUEST,
+                    "400 Bad Request",
+                    "Logout Failed",
+                    "Refresh token has expired. Please provide a valid refresh token."
+            );
             return;
         }
 
         // Validate token category
         String category = jwtUtil.getCategory(refresh);
         if (!category.equals("refresh")) {
-            writeErrorResponse(response, "Invalid token type. Expected a refresh token.");
+            ResponseUtil.writeErrorResponse(
+                    response,
+                    HttpStatus.BAD_REQUEST,
+                    "400 Bad Request",
+                    "Logout Failed",
+                    "Invalid token type. Expected a refresh token."
+            );
             return;
         }
 
         // Check if token exists in the database
         Boolean isExist = refreshRepository.existsByRefresh(refresh);
         if (!isExist) {
-            writeErrorResponse(response, "Refresh token not found in the database. Please log in again.");
+            ResponseUtil.writeErrorResponse(
+                    response,
+                    HttpStatus.BAD_REQUEST,
+                    "400 Bad Request",
+                    "Logout Failed",
+                    "Refresh token not found in the database. Please log in again."
+            );
             return;
         }
-
-        // Proceed with logout
-        refreshRepository.deleteByRefresh(refresh);
 
         // Invalidate the refresh token cookie
         Cookie cookie = new Cookie("refresh", null);
@@ -94,35 +111,6 @@ public class CustomLogoutFilter extends GenericFilterBean {
         cookie.setPath("/");
         response.addCookie(cookie);
 
-        // Send successful logout response
-        response.setStatus(HttpServletResponse.SC_OK);
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-
-        Map<String, Object> responseBody = new HashMap<>();
-        responseBody.put("data", null);
-        responseBody.put("error", null);
-
-        try (PrintWriter out = response.getWriter()) {
-            out.write(objectMapper.writeValueAsString(responseBody));
-        }
-    }
-
-    private void writeErrorResponse(HttpServletResponse response, String errorMessage) throws IOException {
-        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-
-        Map<String, Object> responseBody = new HashMap<>();
-        responseBody.put("data", null);
-        responseBody.put("error", new ServerErrorDTO(
-                "400 Bad Request",
-                "Logout Failed",
-                errorMessage
-        ));
-
-        try (PrintWriter out = response.getWriter()) {
-            out.write(objectMapper.writeValueAsString(responseBody));
-        }
+        ResponseUtil.writeSuccessResponse(response, null);
     }
 }

--- a/src/main/java/com/example/comitserver/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/example/comitserver/jwt/CustomLogoutFilter.java
@@ -58,8 +58,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
             ResponseUtil.writeErrorResponse(
                     response,
                     HttpStatus.BAD_REQUEST,
-                    "Bad Request",
-                    "Logout Failed",
+                    "Logout/TokenMissing",
                     "Refresh token is missing. Please provide a valid refresh token."
             );
             return;
@@ -72,8 +71,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
             ResponseUtil.writeErrorResponse(
                     response,
                     HttpStatus.UNAUTHORIZED,
-                    "Unauthorized",
-                    "Logout Failed",
+                    "Logout/TokenExpired",
                     "Refresh token has expired. Please provide a valid refresh token."
             );
             return;
@@ -85,8 +83,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
             ResponseUtil.writeErrorResponse(
                     response,
                     HttpStatus.BAD_REQUEST,
-                    "Bad Request",
-                    "Logout Failed",
+                    "Logout/InvalidToken",
                     "Invalid token type. Expected a refresh token."
             );
             return;
@@ -98,8 +95,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
             ResponseUtil.writeErrorResponse(
                     response,
                     HttpStatus.NOT_FOUND,
-                    "Not Found",
-                    "Logout Failed",
+                    "Logout/TokenNotFound",
                     "Refresh token not found in the database. Please log in again."
             );
             return;

--- a/src/main/java/com/example/comitserver/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/example/comitserver/jwt/CustomLogoutFilter.java
@@ -107,6 +107,6 @@ public class CustomLogoutFilter extends GenericFilterBean {
         cookie.setPath("/");
         response.addCookie(cookie);
 
-        ResponseUtil.writeSuccessResponse(response, null);
+        ResponseUtil.writeSuccessResponse(response, null, HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/example/comitserver/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/example/comitserver/jwt/CustomLogoutFilter.java
@@ -107,6 +107,6 @@ public class CustomLogoutFilter extends GenericFilterBean {
         cookie.setPath("/");
         response.addCookie(cookie);
 
-        ResponseUtil.writeSuccessResponse(response, null, HttpStatus.NO_CONTENT);
+        ResponseUtil.writeSuccessResponse(response, null, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/comitserver/jwt/LoginFilter.java
+++ b/src/main/java/com/example/comitserver/jwt/LoginFilter.java
@@ -74,7 +74,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         user.put("id", userId);
         user.put("username", username);
 
-        ResponseUtil.writeSuccessResponse(response, user);
+        ResponseUtil.writeSuccessResponse(response, user, HttpStatus.OK);
     }
 
     @Override

--- a/src/main/java/com/example/comitserver/jwt/LoginFilter.java
+++ b/src/main/java/com/example/comitserver/jwt/LoginFilter.java
@@ -85,7 +85,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
             ResponseUtil.writeErrorResponse(
                     response,
                     HttpStatus.UNAUTHORIZED,
-                    "401 Unauthorized",
+                    "Unauthorized",
                     "Authentication Failed",
                     "Invalid email or password."
             );
@@ -93,7 +93,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
             ResponseUtil.writeErrorResponse(
                     response,
                     HttpStatus.BAD_REQUEST,
-                    "400 Bad Request",
+                    "Bad Request",
                     "Authentication Failed",
                     "An unknown error occurred. Please check your request and try again later."
             );

--- a/src/main/java/com/example/comitserver/jwt/LoginFilter.java
+++ b/src/main/java/com/example/comitserver/jwt/LoginFilter.java
@@ -85,16 +85,14 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
             ResponseUtil.writeErrorResponse(
                     response,
                     HttpStatus.UNAUTHORIZED,
-                    "Unauthorized",
-                    "Authentication Failed",
+                    "Login/InvalidFormat",
                     "Invalid email or password."
             );
         } else {
             ResponseUtil.writeErrorResponse(
                     response,
                     HttpStatus.BAD_REQUEST,
-                    "Bad Request",
-                    "Authentication Failed",
+                    "Login/AuthenticationFailed",
                     "An unknown error occurred. Please check your request and try again later."
             );
         }

--- a/src/main/java/com/example/comitserver/jwt/LoginFilter.java
+++ b/src/main/java/com/example/comitserver/jwt/LoginFilter.java
@@ -1,7 +1,6 @@
 package com.example.comitserver.jwt;
 
-import com.example.comitserver.dto.CustomUserDetails;
-import com.example.comitserver.dto.LoginDTO;
+import com.example.comitserver.dto.*;
 import com.example.comitserver.entity.RefreshEntity;
 import com.example.comitserver.repository.RefreshRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -9,10 +8,13 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.util.StreamUtils;
 
@@ -26,6 +28,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     private final AuthenticationManager authenticationManager;
     private final JWTUtil jwtUtil;
     private final RefreshRepository refreshRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     public LoginFilter(AuthenticationManager authenticationManager, JWTUtil jwtUtil, RefreshRepository refreshRepository) {
         this.authenticationManager = authenticationManager;
@@ -39,58 +42,79 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         LoginDTO loginDTO;
 
         try {
-            ObjectMapper objectMapper = new ObjectMapper();
             ServletInputStream inputStream = request.getInputStream();
             String messageBody = StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
             loginDTO = objectMapper.readValue(messageBody, LoginDTO.class);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Failed to parse login request", e);
         }
 
         String email = loginDTO.getEmail();
         String password = loginDTO.getPassword();
 
         UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(email, password);
-
         return authenticationManager.authenticate(authToken);
     }
 
+    private void writeResponse(HttpServletResponse response, ServerResponseDTO serverResponseDTO, HttpStatus status) throws IOException {
+        response.setStatus(status.value()); // Set the HTTP status code
+        objectMapper.writeValue(response.getWriter(), serverResponseDTO); // Write the JSON response body
+    }
+
     @Override
-    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws IOException {
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
         Long userId = userDetails.getUserId();
         String username = userDetails.getUsername();
 
-        // 토큰 생성
         String accessToken = jwtUtil.createJwt("access", userId, 1800000L);
         String refreshToken = jwtUtil.createJwt("refresh", userId, 1209600000L);
 
-        // Refresh 토큰 저장
         addRefreshEntity(userId, refreshToken);
 
-        // 응답 설정
         response.setHeader("access", accessToken);
         response.addCookie(JWTUtil.createCookie("refresh", refreshToken));
-
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        Map<String, Object> responseBody = new HashMap<>();
-        responseBody.put("id", userId);
-        responseBody.put("username", username);
+        Map<String, Object> user = new HashMap<>();
+        user.put("id", userId);
+        user.put("username", username);
 
-        try {
-            objectMapper.writeValue(response.getWriter(), responseBody);
-        } catch (IOException e) {
-            e.printStackTrace();
-            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-        }
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("data", user);
+        responseBody.put("error", null);
+
+        objectMapper.writeValue(response.getWriter(), responseBody);
+        response.setStatus(HttpStatus.OK.value());
     }
 
     @Override
-    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
-        response.setStatus(401);
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> responseBody = new HashMap<>();
+
+        if (failed instanceof BadCredentialsException) {
+            responseBody.put("data", null);
+            responseBody.put("error", new ServerErrorDTO(
+                    "401 Unauthorized",
+                    "Authentication Failed",
+                    "Invalid email or password."
+            ));
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        } else {
+            responseBody.put("data", null);
+            responseBody.put("error", new ServerErrorDTO(
+                    "400 Bad Request",
+                    "Authentication Failed",
+                    "An unknown error occurred. Please check your request and try again later."
+            ));
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        }
+
+        objectMapper.writeValue(response.getWriter(), responseBody);
     }
 
     private void addRefreshEntity(Long userId, String refresh) {

--- a/src/main/java/com/example/comitserver/service/JoinService.java
+++ b/src/main/java/com/example/comitserver/service/JoinService.java
@@ -3,6 +3,7 @@ package com.example.comitserver.service;
 import com.example.comitserver.dto.JoinDTO;
 import com.example.comitserver.entity.Role;
 import com.example.comitserver.entity.UserEntity;
+import com.example.comitserver.exception.DuplicateResourceException;
 import com.example.comitserver.repository.UserRepository;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -17,26 +18,21 @@ public class JoinService {
         this.bCryptPasswordEncoder = bCryptPasswordEncoder;
     }
 
-    public void joinProcess(JoinDTO joinDTO) {
+    public UserEntity joinProcess(JoinDTO joinDTO) {
         String username = joinDTO.getUsername();
         String password = joinDTO.getPassword();
         String phoneNumber = joinDTO.getPhoneNumber();
         String studentId = joinDTO.getStudentId();
         String email = joinDTO.getEmail();
 
-        // Check if email is already in use
-        if (userRepository.existsByEmail(email)) {
-            throw new IllegalArgumentException("Email already exists");
+        if (userRepository.existsByEmail(joinDTO.getEmail())) {
+            throw new DuplicateResourceException("Email is already in use.");
         }
-
-        // Check if student ID is already in use
-        if (userRepository.existsByStudentId(studentId)) {
-            throw new IllegalArgumentException("Student ID already exists");
+        if (userRepository.existsByStudentId(joinDTO.getStudentId())) {
+            throw new DuplicateResourceException("Student ID is already in use.");
         }
-
-        // Check if phone number is already in use
-        if (userRepository.existsByPhoneNumber(phoneNumber)) {
-            throw new IllegalArgumentException("Phone number already exists");
+        if (userRepository.existsByPhoneNumber(joinDTO.getPhoneNumber())) {
+            throw new DuplicateResourceException("Phone number is already in use.");
         }
 
         UserEntity data = new UserEntity();
@@ -52,5 +48,7 @@ public class JoinService {
         data.setIsStaff(false);
 
         userRepository.save(data);
+
+        return data;
     }
 }

--- a/src/main/java/com/example/comitserver/service/ReissueService.java
+++ b/src/main/java/com/example/comitserver/service/ReissueService.java
@@ -1,11 +1,15 @@
 package com.example.comitserver.service;
 
+import com.example.comitserver.dto.CustomUserDetails;
 import com.example.comitserver.entity.RefreshEntity;
 import com.example.comitserver.jwt.JWTUtil;
 import com.example.comitserver.repository.RefreshRepository;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.util.Date;
@@ -75,5 +79,18 @@ public class ReissueService {
         refreshEntity.setExpiration(date.toString());
 
         refreshRepository.save(refreshEntity);
+    }
+
+    public boolean isUserIdValidForToken(String refreshToken, Long userId) {
+        Long tokenUserId = getUserIdFromToken(refreshToken);
+        return tokenUserId.equals(userId);
+    }
+
+    public Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof UserDetails userDetails) {
+            return ((CustomUserDetails) userDetails).getUserId();
+        }
+        return null;
     }
 }

--- a/src/main/java/com/example/comitserver/service/ReissueService.java
+++ b/src/main/java/com/example/comitserver/service/ReissueService.java
@@ -80,17 +80,4 @@ public class ReissueService {
 
         refreshRepository.save(refreshEntity);
     }
-
-    public boolean isUserIdValidForToken(String refreshToken, Long userId) {
-        Long tokenUserId = getUserIdFromToken(refreshToken);
-        return tokenUserId.equals(userId);
-    }
-
-    public Long getCurrentUserId() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication != null && authentication.getPrincipal() instanceof UserDetails userDetails) {
-            return ((CustomUserDetails) userDetails).getUserId();
-        }
-        return null;
-    }
 }

--- a/src/main/java/com/example/comitserver/uitls/ResponseUtil.java
+++ b/src/main/java/com/example/comitserver/uitls/ResponseUtil.java
@@ -16,7 +16,7 @@ public class ResponseUtil {
 
     // Create error response in controller
     public static ResponseEntity<ServerResponseDTO> createErrorResponse(HttpStatus status, String errorType, String detail) {
-        ServerErrorDTO errorDTO = new ServerErrorDTO(errorType + "/" + status.toString().split(" ")[1], detail);
+        ServerErrorDTO errorDTO = new ServerErrorDTO(errorType, detail);
         ServerResponseDTO responseDTO = new ServerResponseDTO(errorDTO, null);
         return new ResponseEntity<>(responseDTO, status);
     }
@@ -38,7 +38,7 @@ public class ResponseUtil {
         Map<String, Object> responseBody = new HashMap<>();
         responseBody.put("data", null);
         responseBody.put("error", new ServerErrorDTO(
-                errorType + "/" + status.toString().split(" ")[1],
+                errorType,
                 detail
         ));
 

--- a/src/main/java/com/example/comitserver/uitls/ResponseUtil.java
+++ b/src/main/java/com/example/comitserver/uitls/ResponseUtil.java
@@ -1,0 +1,65 @@
+package com.example.comitserver.uitls;
+
+import com.example.comitserver.dto.ServerErrorDTO;
+import com.example.comitserver.dto.ServerResponseDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ResponseUtil {
+
+    // Create error response in controller
+    public static ResponseEntity<ServerResponseDTO> createErrorResponse(HttpStatus status, String errorType, String title, String detail) {
+        ServerErrorDTO errorDTO = new ServerErrorDTO(errorType, title, detail);
+        ServerResponseDTO responseDTO = new ServerResponseDTO(errorDTO, null);
+        return new ResponseEntity<>(responseDTO, status);
+    }
+
+    // Create success response in controller
+    public static ResponseEntity<ServerResponseDTO> createSuccessResponse(Object data) {
+        ServerResponseDTO responseDTO = new ServerResponseDTO(null, data);
+        return new ResponseEntity<>(responseDTO, HttpStatus.OK);
+    }
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    // Write error response in filter
+    public static void writeErrorResponse(HttpServletResponse response, HttpStatus status, String errorType, String title, String detail) throws IOException {
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("data", null);
+        responseBody.put("error", new ServerErrorDTO(
+                errorType,
+                title,
+                detail
+        ));
+
+        try (PrintWriter out = response.getWriter()) {
+            out.write(objectMapper.writeValueAsString(responseBody));
+        }
+    }
+
+    // Write success response in filter
+    public static void writeSuccessResponse(HttpServletResponse response, Object data) throws IOException {
+        response.setStatus(HttpStatus.OK.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("data", data);
+        responseBody.put("error", null);
+
+        try (PrintWriter out = response.getWriter()) {
+            out.write(objectMapper.writeValueAsString(responseBody));
+        }
+    }
+}

--- a/src/main/java/com/example/comitserver/uitls/ResponseUtil.java
+++ b/src/main/java/com/example/comitserver/uitls/ResponseUtil.java
@@ -10,13 +10,14 @@ import org.springframework.http.ResponseEntity;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 public class ResponseUtil {
 
     // Create error response in controller
-    public static ResponseEntity<ServerResponseDTO> createErrorResponse(HttpStatus status, String errorType, String title, String detail) {
-        ServerErrorDTO errorDTO = new ServerErrorDTO(errorType, title, detail);
+    public static ResponseEntity<ServerResponseDTO> createErrorResponse(HttpStatus status, String errorType, String detail) {
+        ServerErrorDTO errorDTO = new ServerErrorDTO(errorType + "/" + status.toString().split(" ")[1], detail);
         ServerResponseDTO responseDTO = new ServerResponseDTO(errorDTO, null);
         return new ResponseEntity<>(responseDTO, status);
     }
@@ -30,7 +31,7 @@ public class ResponseUtil {
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     // Write error response in filter
-    public static void writeErrorResponse(HttpServletResponse response, HttpStatus status, String errorType, String title, String detail) throws IOException {
+    public static void writeErrorResponse(HttpServletResponse response, HttpStatus status, String errorType, String detail) throws IOException {
         response.setStatus(status.value());
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
@@ -38,8 +39,7 @@ public class ResponseUtil {
         Map<String, Object> responseBody = new HashMap<>();
         responseBody.put("data", null);
         responseBody.put("error", new ServerErrorDTO(
-                errorType,
-                title,
+                errorType + "/" + status.toString().split(" ")[1],
                 detail
         ));
 

--- a/src/main/java/com/example/comitserver/uitls/ResponseUtil.java
+++ b/src/main/java/com/example/comitserver/uitls/ResponseUtil.java
@@ -10,7 +10,6 @@ import org.springframework.http.ResponseEntity;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 public class ResponseUtil {
@@ -23,9 +22,9 @@ public class ResponseUtil {
     }
 
     // Create success response in controller
-    public static ResponseEntity<ServerResponseDTO> createSuccessResponse(Object data) {
+    public static ResponseEntity<ServerResponseDTO> createSuccessResponse(Object data, HttpStatus status) {
         ServerResponseDTO responseDTO = new ServerResponseDTO(null, data);
-        return new ResponseEntity<>(responseDTO, HttpStatus.OK);
+        return new ResponseEntity<>(responseDTO, status);
     }
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
@@ -49,8 +48,8 @@ public class ResponseUtil {
     }
 
     // Write success response in filter
-    public static void writeSuccessResponse(HttpServletResponse response, Object data) throws IOException {
-        response.setStatus(HttpStatus.OK.value());
+    public static void writeSuccessResponse(HttpServletResponse response, Object data, HttpStatus status) throws IOException {
+        response.setStatus(status.value());
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
 


### PR DESCRIPTION
### Description
<!-- Please explain what this PR is solving -->
## 1. ServerErrorDTO와 ServerResponseDTO를 추가

```
{
    "data": {
        "id": 5,
        "username": "admin"
    },
    "error": null
}
```
```
{
    "data": null,
    "error": {
        "errorType": "Login/InvalidFormat",
        "detail": "Invalid email or password."
    }
}
```

모든 Response를 위와 같은 형태로 통일합니다

## 2. 회원가입 시 validation 추가
1. 비밀번호 6자 이상
2. 학번 반드시 10자 숫자
3. 전화번호는 반드시 숫자
4. 이메일 형식 준수
invalid 할 경우의 에러 핸들링 완료

## 3. Response Util 추가
Response를 더 쉽게 작성하도록 Response Util을 추가했습니다!

Controller용과 Filter 전용이 있는데
Filter의 경우 Login과 Logout 과 같은 특수한 상황에서만 쓰입니다

따라서 대부분의 일반적인 API를 작성할 때는 Controller 용인
`createErrorResponse`와 `createSuccessResponse` 를 사용해주시기 바랍니다!

<!-- Please close the issue (Closes #<issue number>) -->

### Additional context

<!-- Please specify the point to focus during code review -->
