### PR TITLE
feat: add StudyAPI CRUD for client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'io.github.cdimascio:java-dotenv:5.2.2'
 
+	implementation group: 'org.modelmapper', name: 'modelmapper', version: '2.3.8'
+
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'io.github.cdimascio:java-dotenv:5.2.2'
 
-	implementation group: 'org.modelmapper', name: 'modelmapper', version: '2.3.8'
+	implementation group: 'org.modelmapper', name: 'modelmapper', version: '3.0.0'
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'

--- a/src/main/java/com/example/comitserver/SpringConfig.java
+++ b/src/main/java/com/example/comitserver/SpringConfig.java
@@ -1,9 +1,12 @@
 package com.example.comitserver;
 
+import com.example.comitserver.dto.StudyDTO;
+import com.example.comitserver.entity.StudyEntity;
 import com.example.comitserver.repository.StudyRepository;
 import com.example.comitserver.repository.UserRepository;
 import com.example.comitserver.service.StudyService;
 import org.modelmapper.ModelMapper;
+import org.modelmapper.PropertyMap;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,18 +14,18 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SpringConfig {
 
-    private final StudyRepository studyRepository;
-
-    @Autowired
-    public SpringConfig(StudyRepository studyRepository) {this.studyRepository = studyRepository;}
-
-    @Bean
-    public StudyService studyService() {
-        return new StudyService(studyRepository);
-    }
-
     @Bean
     public ModelMapper modelMapper() {
-        return new ModelMapper();
+        ModelMapper modelMapper = new ModelMapper();
+
+        // Entity와 DTO의 attribute가 아예 똑같은 게 아니라면 이런 식으로 설정할 수 있다.
+        modelMapper.addMappings(new PropertyMap<StudyEntity, StudyDTO>() {
+            @Override
+            protected void configure() {
+                map(source.getMentor().getUsername(), destination.getMentorName());
+                map(source.getMentor().getId(), destination.getMentorId());
+            }
+        });
+        return modelMapper;
     }
 }

--- a/src/main/java/com/example/comitserver/SpringConfig.java
+++ b/src/main/java/com/example/comitserver/SpringConfig.java
@@ -1,0 +1,28 @@
+package com.example.comitserver;
+
+import com.example.comitserver.repository.StudyRepository;
+import com.example.comitserver.repository.UserRepository;
+import com.example.comitserver.service.StudyService;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SpringConfig {
+
+    private final StudyRepository studyRepository;
+
+    @Autowired
+    public SpringConfig(StudyRepository studyRepository) {this.studyRepository = studyRepository;}
+
+    @Bean
+    public StudyService studyService() {
+        return new StudyService(studyRepository);
+    }
+
+    @Bean
+    public ModelMapper modelMapper() {
+        return new ModelMapper();
+    }
+}

--- a/src/main/java/com/example/comitserver/config/SecurityConfig.java
+++ b/src/main/java/com/example/comitserver/config/SecurityConfig.java
@@ -75,7 +75,7 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests((auth) -> auth
                 // /login, /join, /logout, /reissue 경로는 모든 사용자에게 열어둠
-                .requestMatchers("/api/login", "/api/join", "/api/logout", "/api/reissue").permitAll()
+                .requestMatchers("/api/login", "/api/join", "/api/logout", "/api/reissue", "/api/studies", "/api/studies/{id}").permitAll()
                 // /admin 경로는 ADMIN 역할만 접근 가능
                 .requestMatchers("/api/admin/**").hasRole("ADMIN")
                 // /admin 외의 GET 요청은 MEMBER, VERIFIED, ADMIN 모두 접근 가능

--- a/src/main/java/com/example/comitserver/controller/JoinController.java
+++ b/src/main/java/com/example/comitserver/controller/JoinController.java
@@ -5,7 +5,7 @@ import com.example.comitserver.dto.ServerResponseDTO;
 import com.example.comitserver.entity.UserEntity;
 import com.example.comitserver.exception.DuplicateResourceException;
 import com.example.comitserver.service.JoinService;
-import com.example.comitserver.uitls.ResponseUtil;
+import com.example.comitserver.utils.ResponseUtil;
 import jakarta.validation.Valid;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/example/comitserver/controller/ReissueController.java
+++ b/src/main/java/com/example/comitserver/controller/ReissueController.java
@@ -2,7 +2,7 @@ package com.example.comitserver.controller;
 
 import com.example.comitserver.jwt.JWTUtil;
 import com.example.comitserver.service.ReissueService;
-import com.example.comitserver.uitls.ResponseUtil;
+import com.example.comitserver.utils.ResponseUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/example/comitserver/controller/StudyController.java
+++ b/src/main/java/com/example/comitserver/controller/StudyController.java
@@ -4,6 +4,7 @@ import com.example.comitserver.dto.StudyDTO;
 import com.example.comitserver.entity.StudyEntity;
 import com.example.comitserver.service.StudyService;
 import org.modelmapper.ModelMapper;
+import org.modelmapper.PropertyMap;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -35,7 +36,7 @@ public class StudyController {
     }
 
     @GetMapping("/studies/{id}")
-    public ResponseEntity<StudyDTO> getStudy(@PathVariable Long id) {
+    public ResponseEntity<StudyDTO> getStudyById(@PathVariable Long id) {
         StudyEntity study = studyService.showStudy(id);
 
         return ResponseEntity.ok(modelMapper.map(study, StudyDTO.class));

--- a/src/main/java/com/example/comitserver/controller/StudyController.java
+++ b/src/main/java/com/example/comitserver/controller/StudyController.java
@@ -1,0 +1,77 @@
+package com.example.comitserver.controller;
+
+import com.example.comitserver.dto.StudyDTO;
+import com.example.comitserver.entity.StudyEntity;
+import com.example.comitserver.service.StudyService;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api")
+public class StudyController {
+
+    private final StudyService studyService;
+    private final ModelMapper modelMapper;
+
+    @Autowired
+    public StudyController(StudyService studyService, ModelMapper modelMapper) {
+        this.studyService = studyService;
+        this.modelMapper = modelMapper;
+    }
+
+    @GetMapping("/studies")
+    public ResponseEntity<List<StudyDTO>> getStudies() {
+        List<StudyEntity> allStudies = studyService.showAllStudies();
+        List<StudyDTO> allStudiesDTO = allStudies.stream().map(entity -> modelMapper.map(entity, StudyDTO.class)).collect(Collectors.toList());
+
+        return ResponseEntity.ok(allStudiesDTO);
+    }
+
+    @GetMapping("/studies/{id}")
+    public ResponseEntity<StudyDTO> getStudy(@PathVariable Long id) {
+        StudyEntity study = studyService.showStudy(id);
+
+        return ResponseEntity.ok(modelMapper.map(study, StudyDTO.class));
+    }
+
+    @PostMapping("/studies")
+    public ResponseEntity<StudyDTO> postStudy(@RequestBody StudyDTO studyDTO) {
+        StudyEntity newStudy = studyService.createStudy(studyDTO);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(newStudy.getId())
+                .toUri();
+
+        return ResponseEntity.created(location).body(modelMapper.map(newStudy, StudyDTO.class));
+    }
+
+    @PutMapping("/studies/{id}")
+    public ResponseEntity<StudyDTO> putStudy(@PathVariable Long id, @RequestBody StudyDTO studyDTO) {
+        StudyEntity updatedStudy = studyService.updateStudy(id, studyDTO);
+
+        if (updatedStudy == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(modelMapper.map(updatedStudy, StudyDTO.class));
+    }
+
+    @DeleteMapping("/studies/{id}")
+    public ResponseEntity<StudyDTO> deleteStudy(@PathVariable Long id) {
+        StudyEntity deletedStudy = studyService.showStudy(id);
+
+        studyService.deleteStudy(id);
+
+        return ResponseEntity.ok(modelMapper.map(deletedStudy, StudyDTO.class));
+    }
+
+}

--- a/src/main/java/com/example/comitserver/dto/StudyDTO.java
+++ b/src/main/java/com/example/comitserver/dto/StudyDTO.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 @Data
 public class StudyDTO {
-    private String id;
+    private Long id;
     private String title;
     private String imageSrc;
     private String mentor;
@@ -21,6 +21,6 @@ public class StudyDTO {
     private List<String> stacks;
     private Campus campus;
     private String description;
-    private boolean isRecruiting;
+    private Boolean isRecruiting;
     private Semester semester;
 }

--- a/src/main/java/com/example/comitserver/dto/StudyDTO.java
+++ b/src/main/java/com/example/comitserver/dto/StudyDTO.java
@@ -13,7 +13,8 @@ public class StudyDTO {
     private Long id;
     private String title;
     private String imageSrc;
-    private String mentor;
+    private String mentorName;
+    private Long mentorId;
     private Day day;
     private String startTime;
     private String endTime;

--- a/src/main/java/com/example/comitserver/dto/StudyDTO.java
+++ b/src/main/java/com/example/comitserver/dto/StudyDTO.java
@@ -1,0 +1,26 @@
+package com.example.comitserver.dto;
+
+import com.example.comitserver.entity.enumeration.Campus;
+import com.example.comitserver.entity.enumeration.Day;
+import com.example.comitserver.entity.enumeration.Level;
+import com.example.comitserver.entity.enumeration.Semester;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class StudyDTO {
+    private String id;
+    private String title;
+    private String imageSrc;
+    private String mentor;
+    private Day day;
+    private String startTime;
+    private String endTime;
+    private Level level;
+    private List<String> stacks;
+    private Campus campus;
+    private String description;
+    private boolean isRecruiting;
+    private Semester semester;
+}

--- a/src/main/java/com/example/comitserver/entity/StudyEntity.java
+++ b/src/main/java/com/example/comitserver/entity/StudyEntity.java
@@ -1,0 +1,67 @@
+package com.example.comitserver.entity;
+
+import com.example.comitserver.entity.enumeration.Campus;
+import com.example.comitserver.entity.enumeration.Day;
+import com.example.comitserver.entity.enumeration.Level;
+import com.example.comitserver.entity.enumeration.Semester;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StudyEntity extends BaseTimeEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private String id;
+
+    @Column(nullable = false) // 원래 필드명과 db 열 이름이 같으며 안 적어도 되는데 속성이 있어서 적는 거
+    private String title;
+
+    @Column(nullable = false)
+    private String imageSrc;
+
+    @Column(nullable = false) // ❓member 전체를 불러와야할지 그냥 이름만 string으로 불러오면 될지 추후에 다시 보자.
+    private String mentor;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Day day;
+
+    @Column(nullable = false)
+    private String startTime;
+
+    @Column(nullable = false)
+    private String endTime;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Level level;
+
+    @ElementCollection // 배열은 애초에 안 되고 list나 set은 이렇게 따로 collection을 만들어서 관계형으로 설정해야함
+    @CollectionTable(name="study_stacks", joinColumns = @JoinColumn(name="study_id"))
+    @Column(name="stack", nullable = false)
+    private List<String> stacks;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Campus campus;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private boolean isRecruiting;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Semester semester;
+}

--- a/src/main/java/com/example/comitserver/entity/StudyEntity.java
+++ b/src/main/java/com/example/comitserver/entity/StudyEntity.java
@@ -29,8 +29,9 @@ public class StudyEntity extends BaseTimeEntity{
     @Column(nullable = false)
     private String imageSrc;
 
-    @Column(nullable = false) // ❓member 전체를 불러와야할지 그냥 이름만 string으로 불러오면 될지 추후에 다시 보자.
-    private String mentor;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserEntity mentor;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/com/example/comitserver/entity/StudyEntity.java
+++ b/src/main/java/com/example/comitserver/entity/StudyEntity.java
@@ -21,7 +21,7 @@ public class StudyEntity extends BaseTimeEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private String id;
+    private Long id;
 
     @Column(nullable = false) // 원래 필드명과 db 열 이름이 같으며 안 적어도 되는데 속성이 있어서 적는 거
     private String title;
@@ -59,7 +59,7 @@ public class StudyEntity extends BaseTimeEntity{
     private String description;
 
     @Column(nullable = false)
-    private boolean isRecruiting;
+    private Boolean isRecruiting;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/com/example/comitserver/entity/enumeration/Campus.java
+++ b/src/main/java/com/example/comitserver/entity/enumeration/Campus.java
@@ -1,0 +1,8 @@
+package com.example.comitserver.entity.enumeration;
+
+public enum Campus {
+    공통,
+    온라인,
+    명륜,
+    율전
+}

--- a/src/main/java/com/example/comitserver/entity/enumeration/Day.java
+++ b/src/main/java/com/example/comitserver/entity/enumeration/Day.java
@@ -1,0 +1,5 @@
+package com.example.comitserver.entity.enumeration;
+
+public enum Day {
+    월,화,수,목,금,토,일
+}

--- a/src/main/java/com/example/comitserver/entity/enumeration/Level.java
+++ b/src/main/java/com/example/comitserver/entity/enumeration/Level.java
@@ -1,0 +1,7 @@
+package com.example.comitserver.entity.enumeration;
+
+public enum Level {
+    초급,
+    중급,
+    고급
+}

--- a/src/main/java/com/example/comitserver/entity/enumeration/Semester.java
+++ b/src/main/java/com/example/comitserver/entity/enumeration/Semester.java
@@ -1,0 +1,6 @@
+package com.example.comitserver.entity.enumeration;
+
+public enum Semester {
+    Spring_24,
+    Fall_24
+}

--- a/src/main/java/com/example/comitserver/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/example/comitserver/jwt/CustomLogoutFilter.java
@@ -1,7 +1,7 @@
 package com.example.comitserver.jwt;
 
 import com.example.comitserver.repository.RefreshRepository;
-import com.example.comitserver.uitls.ResponseUtil;
+import com.example.comitserver.utils.ResponseUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;

--- a/src/main/java/com/example/comitserver/jwt/LoginFilter.java
+++ b/src/main/java/com/example/comitserver/jwt/LoginFilter.java
@@ -3,7 +3,7 @@ package com.example.comitserver.jwt;
 import com.example.comitserver.dto.*;
 import com.example.comitserver.entity.RefreshEntity;
 import com.example.comitserver.repository.RefreshRepository;
-import com.example.comitserver.uitls.ResponseUtil;
+import com.example.comitserver.utils.ResponseUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletInputStream;

--- a/src/main/java/com/example/comitserver/repository/StudyRepository.java
+++ b/src/main/java/com/example/comitserver/repository/StudyRepository.java
@@ -1,0 +1,6 @@
+package com.example.comitserver.repository;
+
+import com.example.comitserver.entity.StudyEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyRepository extends JpaRepository<StudyEntity, Long> {}

--- a/src/main/java/com/example/comitserver/service/StudyService.java
+++ b/src/main/java/com/example/comitserver/service/StudyService.java
@@ -3,20 +3,23 @@ package com.example.comitserver.service;
 import com.example.comitserver.dto.StudyDTO;
 import com.example.comitserver.entity.StudyEntity;
 import com.example.comitserver.repository.StudyRepository;
+import com.example.comitserver.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.NoSuchElementException;
 
-//@Service
+@Service
 @Transactional
 public class StudyService {
 
     private final StudyRepository studyRepository;
+    private final UserRepository userRepository;
 
-    public StudyService(StudyRepository studyRepository) {
+    public StudyService(StudyRepository studyRepository, UserRepository userRepository) {
         this.studyRepository = studyRepository;
+        this.userRepository = userRepository;
     }
 
     public List<StudyEntity> showAllStudies() {
@@ -33,7 +36,7 @@ public class StudyService {
 
         newStudy.setTitle(studyDTO.getTitle());
         newStudy.setImageSrc(studyDTO.getImageSrc());
-        newStudy.setMentor(studyDTO.getMentor());
+        newStudy.setMentor(userRepository.findById(studyDTO.getMentorId()).orElseThrow(()-> new NoSuchElementException("User not found with id: " + studyDTO.getMentorId())));
         newStudy.setDay(studyDTO.getDay());
         newStudy.setStartTime(studyDTO.getStartTime());
         newStudy.setEndTime(studyDTO.getEndTime());

--- a/src/main/java/com/example/comitserver/service/StudyService.java
+++ b/src/main/java/com/example/comitserver/service/StudyService.java
@@ -1,0 +1,75 @@
+package com.example.comitserver.service;
+
+import com.example.comitserver.dto.StudyDTO;
+import com.example.comitserver.entity.StudyEntity;
+import com.example.comitserver.repository.StudyRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+//@Service
+@Transactional
+public class StudyService {
+
+    private final StudyRepository studyRepository;
+
+    public StudyService(StudyRepository studyRepository) {
+        this.studyRepository = studyRepository;
+    }
+
+    public List<StudyEntity> showAllStudies() {
+        return studyRepository.findAll();
+    }
+
+    public StudyEntity showStudy(Long id) {
+        return studyRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("Study not found with id: " + id));
+    }
+
+    public StudyEntity createStudy(StudyDTO studyDTO) {
+        StudyEntity newStudy = new StudyEntity();
+
+        newStudy.setTitle(studyDTO.getTitle());
+        newStudy.setImageSrc(studyDTO.getImageSrc());
+        newStudy.setMentor(studyDTO.getMentor());
+        newStudy.setDay(studyDTO.getDay());
+        newStudy.setStartTime(studyDTO.getStartTime());
+        newStudy.setEndTime(studyDTO.getEndTime());
+        newStudy.setLevel(studyDTO.getLevel());
+        newStudy.setStacks(studyDTO.getStacks());
+        newStudy.setCampus(studyDTO.getCampus());
+        newStudy.setDescription(studyDTO.getDescription());
+        newStudy.setIsRecruiting(studyDTO.getIsRecruiting());
+        newStudy.setSemester(studyDTO.getSemester());
+        studyRepository.save(newStudy);
+
+        return newStudy;
+
+    }
+
+    public StudyEntity updateStudy(Long id, StudyDTO studyDTO) {
+        StudyEntity updatingStudy = showStudy(id);
+
+        updatingStudy.setTitle(studyDTO.getTitle());
+        updatingStudy.setImageSrc(studyDTO.getImageSrc());
+        updatingStudy.setDay(studyDTO.getDay());
+        updatingStudy.setStartTime(studyDTO.getStartTime());
+        updatingStudy.setEndTime(studyDTO.getEndTime());
+        updatingStudy.setLevel(studyDTO.getLevel());
+        updatingStudy.setStacks(studyDTO.getStacks());
+        updatingStudy.setCampus(studyDTO.getCampus());
+        updatingStudy.setDescription(studyDTO.getDescription());
+        updatingStudy.setIsRecruiting(studyDTO.getIsRecruiting());
+        updatingStudy.setSemester(studyDTO.getSemester());
+        studyRepository.save(updatingStudy);
+
+        return updatingStudy;
+    }
+
+    public void deleteStudy(Long id) {
+        StudyEntity deletingStudy = showStudy(id);
+        studyRepository.delete(deletingStudy);
+    }
+}

--- a/src/main/java/com/example/comitserver/utils/ResponseUtil.java
+++ b/src/main/java/com/example/comitserver/utils/ResponseUtil.java
@@ -1,4 +1,4 @@
-package com.example.comitserver.uitls;
+package com.example.comitserver.utils;
 
 import com.example.comitserver.dto.ServerErrorDTO;
 import com.example.comitserver.dto.ServerResponseDTO;


### PR DESCRIPTION
### Description

<!-- Please explain what this PR is solving -->
- study entity 추가
  - 관련 필요 enum 추가
  - 관련 필요 collection 추가
- study DTO 추가
- study repository 추가
- study service 추가
- study controller 추가
- 코드 리뷰 후 이상이 없을 시, 현재는 그냥 data만 담기는데 error까지 포함하는 형식으로 발전시키고, api/admin 추가 예정 
<!-- Please close the issue (Closes #<issue number>) -->
Closes #8 
### Additional context
<!-- Please specify the point to focus during code review -->
- 기존 스키마와 엔터티 사이에 변경점이 있으니 확인해주시기 바랍니다.
  - 엔터티 attribute로 Array는 아예 안 되고 List도 컬렉션을 만들어 불러오는 식으로만 가져올 수 있어서 그렇게 했습니다.
- 객체들 간의 변환을 해주는 model mapper 라이브러리를 추가했습니다.
- 컨트롤러에서 return을 entity가 아닌 dto로 했습니다. db와 통신할 때 entity를 사용하고 클라이언트와 통신할 때 dto를 사용합니다. User도 이에 맞게 변경하면 좋을 것 같습니다.
- 컨트롤러에서 ResponseEntity를 통해 명시적으로 상태 코드 제어를 나타냅니다.
- RESTful api 표준에 맞게 post 요청에 대한 응답으로 헤더에 uri를 포함합니다.
- 포스트맨 테스트를 위해 security config 권한을 일시적으로 수정하였습니다.(왜 403 뜨는지 머리를 많이 쥐어 뜯었습니다.)

