### PR TITLE
fix: return UserDTO when successfully joined

### DIFF
--- a/src/main/java/com/example/comitserver/controller/JoinController.java
+++ b/src/main/java/com/example/comitserver/controller/JoinController.java
@@ -14,6 +14,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
 
 @RestController
 @RequestMapping("/api")
@@ -30,7 +33,14 @@ public class JoinController {
     public ResponseEntity<?> joinProcess(@RequestBody @Valid JoinDTO joinDTO) {
         UserEntity createdUser = joinService.joinProcess(joinDTO);
         UserDTO userDTO = modelMapper.map(createdUser, UserDTO.class);
-        return ResponseUtil.createSuccessResponse(userDTO, HttpStatus.CREATED);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentContextPath()
+                .path("/api/users/{id}")
+                .buildAndExpand(createdUser.getId())
+                .toUri();
+
+        return ResponseUtil.createSuccessResponse(userDTO, HttpStatus.CREATED, location);
     }
 
     @ExceptionHandler(DuplicateResourceException.class)

--- a/src/main/java/com/example/comitserver/controller/JoinController.java
+++ b/src/main/java/com/example/comitserver/controller/JoinController.java
@@ -2,11 +2,13 @@ package com.example.comitserver.controller;
 
 import com.example.comitserver.dto.JoinDTO;
 import com.example.comitserver.dto.ServerResponseDTO;
+import com.example.comitserver.dto.UserDTO;
 import com.example.comitserver.entity.UserEntity;
 import com.example.comitserver.exception.DuplicateResourceException;
 import com.example.comitserver.service.JoinService;
 import com.example.comitserver.utils.ResponseUtil;
 import jakarta.validation.Valid;
+import org.modelmapper.ModelMapper;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,15 +19,18 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api")
 public class JoinController {
     private final JoinService joinService;
+    private final ModelMapper modelMapper;
 
-    public JoinController(JoinService joinService) {
+    public JoinController(JoinService joinService, ModelMapper modelMapper) {
         this.joinService = joinService;
+        this.modelMapper = modelMapper;
     }
 
     @PostMapping("/join")
     public ResponseEntity<?> joinProcess(@RequestBody @Valid JoinDTO joinDTO) {
         UserEntity createdUser = joinService.joinProcess(joinDTO);
-        return ResponseUtil.createSuccessResponse(createdUser, HttpStatus.CREATED);
+        UserDTO userDTO = modelMapper.map(createdUser, UserDTO.class);
+        return ResponseUtil.createSuccessResponse(userDTO, HttpStatus.CREATED);
     }
 
     @ExceptionHandler(DuplicateResourceException.class)

--- a/src/main/java/com/example/comitserver/utils/ResponseUtil.java
+++ b/src/main/java/com/example/comitserver/utils/ResponseUtil.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,6 +26,14 @@ public class ResponseUtil {
     public static ResponseEntity<ServerResponseDTO> createSuccessResponse(Object data, HttpStatus status) {
         ServerResponseDTO responseDTO = new ServerResponseDTO(null, data);
         return new ResponseEntity<>(responseDTO, status);
+    }
+
+    // Create success response in controller with Location header
+    public static ResponseEntity<ServerResponseDTO> createSuccessResponse(Object data, HttpStatus status, URI location) {
+        ServerResponseDTO responseDTO = new ServerResponseDTO(null, data);
+        return ResponseEntity.status(status)
+                .location(location)
+                .body(responseDTO);
     }
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
@@ -56,6 +65,24 @@ public class ResponseUtil {
         Map<String, Object> responseBody = new HashMap<>();
         responseBody.put("data", data);
         responseBody.put("error", null);
+
+        try (PrintWriter out = response.getWriter()) {
+            out.write(objectMapper.writeValueAsString(responseBody));
+        }
+    }
+
+    // Write success response in filter with Location header
+    public static void writeSuccessResponse(HttpServletResponse response, Object data, HttpStatus status, URI location) throws IOException {
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("data", data);
+        responseBody.put("error", null);
+
+        // Add Location header
+        response.setHeader("Location", location.toString());
 
         try (PrintWriter out = response.getWriter()) {
             out.write(objectMapper.writeValueAsString(responseBody));


### PR DESCRIPTION
### Description
<!-- Please explain what this PR is solving -->

성공적으로 회원가입 성공한 경우 
기존에는 UserEntity를 사용해 data를 반환했지만
UserDTO의 정보들만 반환하도록 수정했습니다

<!-- Please close the issue (Closes #<issue number>) -->
Closes #15 
### Additional context

<!-- Please specify the point to focus during code review -->
