### PR TITLE
feat: improve study entity, DTO and related service, controller

### DIFF
--- a/src/main/java/com/example/comitserver/SpringConfig.java
+++ b/src/main/java/com/example/comitserver/SpringConfig.java
@@ -1,13 +1,6 @@
 package com.example.comitserver;
 
-import com.example.comitserver.dto.StudyDTO;
-import com.example.comitserver.entity.StudyEntity;
-import com.example.comitserver.repository.StudyRepository;
-import com.example.comitserver.repository.UserRepository;
-import com.example.comitserver.service.StudyService;
 import org.modelmapper.ModelMapper;
-import org.modelmapper.PropertyMap;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -19,13 +12,13 @@ public class SpringConfig {
         ModelMapper modelMapper = new ModelMapper();
 
         // Entity와 DTO의 attribute가 아예 똑같은 게 아니라면 이런 식으로 설정할 수 있다.
-        modelMapper.addMappings(new PropertyMap<StudyEntity, StudyDTO>() {
-            @Override
-            protected void configure() {
-                map(source.getMentor().getUsername(), destination.getMentorName());
-                map(source.getMentor().getId(), destination.getMentorId());
-            }
-        });
+//        modelMapper.addMappings(new PropertyMap<StudyEntity, StudyResponseDTO>() {
+//            @Override
+//            protected void configure() {
+//                map(source.getMentor().getUsername(), destination.getMentorName());
+//                map(source.getMentor().getId(), destination.getMentorId());
+//            }
+//        });
         return modelMapper;
     }
 }

--- a/src/main/java/com/example/comitserver/controller/StudyAdminController.java
+++ b/src/main/java/com/example/comitserver/controller/StudyAdminController.java
@@ -1,14 +1,13 @@
 package com.example.comitserver.controller;
 
-import com.example.comitserver.dto.StudyDTO;
+import com.example.comitserver.dto.StudyRequestDTO;
+import com.example.comitserver.dto.StudyResponseDTO;
 import com.example.comitserver.entity.StudyEntity;
 import com.example.comitserver.service.StudyService;
 import org.modelmapper.ModelMapper;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
-import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -25,38 +24,38 @@ public class StudyAdminController {
     }
 
     @GetMapping("/studies")
-    public ResponseEntity<List<StudyDTO>> getStudies() {
+    public ResponseEntity<List<StudyResponseDTO>> getStudies() {
         List<StudyEntity> allStudies = studyService.showAllStudies();
-        List<StudyDTO> allStudiesDTO = allStudies.stream().map(entity -> modelMapper.map(entity, StudyDTO.class)).collect(Collectors.toList());
+        List<StudyResponseDTO> allStudiesDTO = allStudies.stream().map(entity -> modelMapper.map(entity, StudyResponseDTO.class)).collect(Collectors.toList());
 
         return ResponseEntity.ok(allStudiesDTO);
     }
 
     @GetMapping("/studies/{id}")
-    public ResponseEntity<StudyDTO> getStudyById(@PathVariable Long id) {
+    public ResponseEntity<StudyResponseDTO> getStudyById(@PathVariable Long id) {
         StudyEntity study = studyService.showStudy(id);
 
-        return ResponseEntity.ok(modelMapper.map(study, StudyDTO.class));
+        return ResponseEntity.ok(modelMapper.map(study, StudyResponseDTO.class));
     }
 
     @PutMapping("/studies/{id}")
-    public ResponseEntity<StudyDTO> putStudy(@PathVariable Long id, @RequestBody StudyDTO studyDTO) {
-        StudyEntity updatedStudy = studyService.updateStudy(id, studyDTO);
+    public ResponseEntity<StudyResponseDTO> putStudy(@PathVariable Long id, @RequestBody StudyRequestDTO studyRequestDTO) {
+        StudyEntity updatedStudy = studyService.updateStudy(id, studyRequestDTO);
 
         if (updatedStudy == null) {
             return ResponseEntity.notFound().build();
         }
 
-        return ResponseEntity.ok(modelMapper.map(updatedStudy, StudyDTO.class));
+        return ResponseEntity.ok(modelMapper.map(updatedStudy, StudyResponseDTO.class));
     }
 
     @DeleteMapping("/studies/{id}")
-    public ResponseEntity<StudyDTO> deleteStudy(@PathVariable Long id) {
+    public ResponseEntity<StudyResponseDTO> deleteStudy(@PathVariable Long id) {
         StudyEntity deletedStudy = studyService.showStudy(id);
 
         studyService.deleteStudy(id);
 
-        return ResponseEntity.ok(modelMapper.map(deletedStudy, StudyDTO.class));
+        return ResponseEntity.ok(modelMapper.map(deletedStudy, StudyResponseDTO.class));
     }
 
 }

--- a/src/main/java/com/example/comitserver/controller/StudyController.java
+++ b/src/main/java/com/example/comitserver/controller/StudyController.java
@@ -1,12 +1,14 @@
 package com.example.comitserver.controller;
 
-import com.example.comitserver.dto.StudyDTO;
+import com.example.comitserver.dto.CustomUserDetails;
+import com.example.comitserver.dto.StudyRequestDTO;
+import com.example.comitserver.dto.StudyResponseDTO;
 import com.example.comitserver.entity.StudyEntity;
 import com.example.comitserver.service.StudyService;
 import org.modelmapper.ModelMapper;
-import org.modelmapper.PropertyMap;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -28,51 +30,51 @@ public class StudyController {
     }
 
     @GetMapping("/studies")
-    public ResponseEntity<List<StudyDTO>> getStudies() {
+    public ResponseEntity<List<StudyResponseDTO>> getStudies() {
         List<StudyEntity> allStudies = studyService.showAllStudies();
-        List<StudyDTO> allStudiesDTO = allStudies.stream().map(entity -> modelMapper.map(entity, StudyDTO.class)).collect(Collectors.toList());
+        List<StudyResponseDTO> allStudiesDTO = allStudies.stream().map(entity -> modelMapper.map(entity, StudyResponseDTO.class)).collect(Collectors.toList());
 
         return ResponseEntity.ok(allStudiesDTO);
     }
 
     @GetMapping("/studies/{id}")
-    public ResponseEntity<StudyDTO> getStudyById(@PathVariable Long id) {
+    public ResponseEntity<StudyResponseDTO> getStudyById(@PathVariable Long id) {
         StudyEntity study = studyService.showStudy(id);
 
-        return ResponseEntity.ok(modelMapper.map(study, StudyDTO.class));
+        return ResponseEntity.ok(modelMapper.map(study, StudyResponseDTO.class));
     }
 
-    @PostMapping("/studies")
-    public ResponseEntity<StudyDTO> postStudy(@RequestBody StudyDTO studyDTO) {
-        StudyEntity newStudy = studyService.createStudy(studyDTO);
-
-        URI location = ServletUriComponentsBuilder
-                .fromCurrentRequest()
-                .path("/{id}")
-                .buildAndExpand(newStudy.getId())
-                .toUri();
-
-        return ResponseEntity.created(location).body(modelMapper.map(newStudy, StudyDTO.class));
-    }
+//    @PostMapping("/studies")
+//    public ResponseEntity<StudyResponseDTO> postStudy(@RequestBody StudyRequestDTO studyRequestDTO, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+//        StudyEntity newStudy = studyService.createStudy(studyRequestDTO, customUserDetails);
+//
+//        URI location = ServletUriComponentsBuilder
+//                .fromCurrentRequest()
+//                .path("/{id}")
+//                .buildAndExpand(newStudy.getId())
+//                .toUri();
+//
+//        return ResponseEntity.created(location).body(modelMapper.map(newStudy, StudyResponseDTO.class));
+//    }
 
     @PutMapping("/studies/{id}")
-    public ResponseEntity<StudyDTO> putStudy(@PathVariable Long id, @RequestBody StudyDTO studyDTO) {
-        StudyEntity updatedStudy = studyService.updateStudy(id, studyDTO);
+    public ResponseEntity<StudyResponseDTO> putStudy(@PathVariable Long id, @RequestBody StudyRequestDTO studyRequestDTO) {
+        StudyEntity updatedStudy = studyService.updateStudy(id, studyRequestDTO);
 
         if (updatedStudy == null) {
             return ResponseEntity.notFound().build();
         }
 
-        return ResponseEntity.ok(modelMapper.map(updatedStudy, StudyDTO.class));
+        return ResponseEntity.ok(modelMapper.map(updatedStudy, StudyResponseDTO.class));
     }
 
     @DeleteMapping("/studies/{id}")
-    public ResponseEntity<StudyDTO> deleteStudy(@PathVariable Long id) {
+    public ResponseEntity<StudyResponseDTO> deleteStudy(@PathVariable Long id) {
         StudyEntity deletedStudy = studyService.showStudy(id);
 
         studyService.deleteStudy(id);
 
-        return ResponseEntity.ok(modelMapper.map(deletedStudy, StudyDTO.class));
+        return ResponseEntity.ok(modelMapper.map(deletedStudy, StudyResponseDTO.class));
     }
 
 }

--- a/src/main/java/com/example/comitserver/controller/StudyController.java
+++ b/src/main/java/com/example/comitserver/controller/StudyController.java
@@ -44,18 +44,18 @@ public class StudyController {
         return ResponseEntity.ok(modelMapper.map(study, StudyResponseDTO.class));
     }
 
-//    @PostMapping("/studies")
-//    public ResponseEntity<StudyResponseDTO> postStudy(@RequestBody StudyRequestDTO studyRequestDTO, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-//        StudyEntity newStudy = studyService.createStudy(studyRequestDTO, customUserDetails);
-//
-//        URI location = ServletUriComponentsBuilder
-//                .fromCurrentRequest()
-//                .path("/{id}")
-//                .buildAndExpand(newStudy.getId())
-//                .toUri();
-//
-//        return ResponseEntity.created(location).body(modelMapper.map(newStudy, StudyResponseDTO.class));
-//    }
+    @PostMapping("/studies")
+    public ResponseEntity<StudyResponseDTO> postStudy(@RequestBody StudyRequestDTO studyRequestDTO, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        StudyEntity newStudy = studyService.createStudy(studyRequestDTO, customUserDetails);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(newStudy.getId())
+                .toUri();
+
+        return ResponseEntity.created(location).body(modelMapper.map(newStudy, StudyResponseDTO.class));
+    }
 
     @PutMapping("/studies/{id}")
     public ResponseEntity<StudyResponseDTO> putStudy(@PathVariable Long id, @RequestBody StudyRequestDTO studyRequestDTO) {

--- a/src/main/java/com/example/comitserver/dto/StudyRequestDTO.java
+++ b/src/main/java/com/example/comitserver/dto/StudyRequestDTO.java
@@ -1,0 +1,25 @@
+package com.example.comitserver.dto;
+
+import com.example.comitserver.entity.enumeration.Campus;
+import com.example.comitserver.entity.enumeration.Day;
+import com.example.comitserver.entity.enumeration.Level;
+import com.example.comitserver.entity.enumeration.Semester;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class StudyRequestDTO {
+    private Long id;
+    private String title;
+    private String imageSrc;
+    private Day day;
+    private String startTime;
+    private String endTime;
+    private Level level;
+    private List<String> stacks;
+    private Campus campus;
+    private String description;
+    private Boolean isRecruiting;
+    private Semester semester;
+}

--- a/src/main/java/com/example/comitserver/dto/StudyResponseDTO.java
+++ b/src/main/java/com/example/comitserver/dto/StudyResponseDTO.java
@@ -1,5 +1,6 @@
 package com.example.comitserver.dto;
 
+import com.example.comitserver.entity.UserEntity;
 import com.example.comitserver.entity.enumeration.Campus;
 import com.example.comitserver.entity.enumeration.Day;
 import com.example.comitserver.entity.enumeration.Level;
@@ -9,12 +10,11 @@ import lombok.Data;
 import java.util.List;
 
 @Data
-public class StudyDTO {
+public class StudyResponseDTO {
     private Long id;
     private String title;
     private String imageSrc;
-    private String mentorName;
-    private Long mentorId;
+    private UserEntity mentor;
     private Day day;
     private String startTime;
     private String endTime;

--- a/src/main/java/com/example/comitserver/service/StudyService.java
+++ b/src/main/java/com/example/comitserver/service/StudyService.java
@@ -1,6 +1,8 @@
 package com.example.comitserver.service;
 
-import com.example.comitserver.dto.StudyDTO;
+import com.example.comitserver.dto.CustomUserDetails;
+import com.example.comitserver.dto.StudyRequestDTO;
+import com.example.comitserver.dto.StudyResponseDTO;
 import com.example.comitserver.entity.StudyEntity;
 import com.example.comitserver.repository.StudyRepository;
 import com.example.comitserver.repository.UserRepository;
@@ -31,41 +33,42 @@ public class StudyService {
                 .orElseThrow(() -> new NoSuchElementException("Study not found with id: " + id));
     }
 
-    public StudyEntity createStudy(StudyDTO studyDTO) {
+    public StudyEntity createStudy(StudyRequestDTO studyRequestDTO, CustomUserDetails customUserDetails) {
         StudyEntity newStudy = new StudyEntity();
 
-        newStudy.setTitle(studyDTO.getTitle());
-        newStudy.setImageSrc(studyDTO.getImageSrc());
-        newStudy.setMentor(userRepository.findById(studyDTO.getMentorId()).orElseThrow(()-> new NoSuchElementException("User not found with id: " + studyDTO.getMentorId())));
-        newStudy.setDay(studyDTO.getDay());
-        newStudy.setStartTime(studyDTO.getStartTime());
-        newStudy.setEndTime(studyDTO.getEndTime());
-        newStudy.setLevel(studyDTO.getLevel());
-        newStudy.setStacks(studyDTO.getStacks());
-        newStudy.setCampus(studyDTO.getCampus());
-        newStudy.setDescription(studyDTO.getDescription());
-        newStudy.setIsRecruiting(studyDTO.getIsRecruiting());
-        newStudy.setSemester(studyDTO.getSemester());
+        newStudy.setTitle(studyRequestDTO.getTitle());
+        newStudy.setImageSrc(studyRequestDTO.getImageSrc());
+       // header의 token에서 user id 가져와서 findByID해서 mentor 넣어야 함
+        newStudy.setMentor(userRepository.findById(customUserDetails.getUserId()).orElseThrow(() -> new NoSuchElementException("User not found with id: " + customUserDetails.getUserId())));
+        newStudy.setDay(studyRequestDTO.getDay());
+        newStudy.setStartTime(studyRequestDTO.getStartTime());
+        newStudy.setEndTime(studyRequestDTO.getEndTime());
+        newStudy.setLevel(studyRequestDTO.getLevel());
+        newStudy.setStacks(studyRequestDTO.getStacks());
+        newStudy.setCampus(studyRequestDTO.getCampus());
+        newStudy.setDescription(studyRequestDTO.getDescription());
+        newStudy.setIsRecruiting(studyRequestDTO.getIsRecruiting());
+        newStudy.setSemester(studyRequestDTO.getSemester());
         studyRepository.save(newStudy);
 
         return newStudy;
 
     }
 
-    public StudyEntity updateStudy(Long id, StudyDTO studyDTO) {
+    public StudyEntity updateStudy(Long id, StudyRequestDTO studyRequestDTO) {
         StudyEntity updatingStudy = showStudy(id);
 
-        updatingStudy.setTitle(studyDTO.getTitle());
-        updatingStudy.setImageSrc(studyDTO.getImageSrc());
-        updatingStudy.setDay(studyDTO.getDay());
-        updatingStudy.setStartTime(studyDTO.getStartTime());
-        updatingStudy.setEndTime(studyDTO.getEndTime());
-        updatingStudy.setLevel(studyDTO.getLevel());
-        updatingStudy.setStacks(studyDTO.getStacks());
-        updatingStudy.setCampus(studyDTO.getCampus());
-        updatingStudy.setDescription(studyDTO.getDescription());
-        updatingStudy.setIsRecruiting(studyDTO.getIsRecruiting());
-        updatingStudy.setSemester(studyDTO.getSemester());
+        updatingStudy.setTitle(studyRequestDTO.getTitle());
+        updatingStudy.setImageSrc(studyRequestDTO.getImageSrc());
+        updatingStudy.setDay(studyRequestDTO.getDay());
+        updatingStudy.setStartTime(studyRequestDTO.getStartTime());
+        updatingStudy.setEndTime(studyRequestDTO.getEndTime());
+        updatingStudy.setLevel(studyRequestDTO.getLevel());
+        updatingStudy.setStacks(studyRequestDTO.getStacks());
+        updatingStudy.setCampus(studyRequestDTO.getCampus());
+        updatingStudy.setDescription(studyRequestDTO.getDescription());
+        updatingStudy.setIsRecruiting(studyRequestDTO.getIsRecruiting());
+        updatingStudy.setSemester(studyRequestDTO.getSemester());
         studyRepository.save(updatingStudy);
 
         return updatingStudy;


### PR DESCRIPTION
### Description

<!-- Please explain what this PR is solving -->
- study entity 수정
  - mentor가 이름만 string으로 저장하는 것에서 user entity 객체 자체를 관계형으로 저장함
- study DTO 수정
  - response와 request DTO로 study DTO를 세분화함. request에서는 mentor가 header에 토큰으로 오고 response에서는 body에 담기기 때문
- study service와 controller도 관련된 내용 코드 수정

<!-- Please close the issue (Closes #<issue number>) -->
Closes #26 
### Additional context

<!-- Please specify the point to focus during code review -->
error fix(issue #18) 필요