### PR TITLE
fix: fix study api error

### DIFF
--- a/src/main/java/com/example/comitserver/controller/StudyController.java
+++ b/src/main/java/com/example/comitserver/controller/StudyController.java
@@ -71,10 +71,11 @@ public class StudyController {
     @DeleteMapping("/studies/{id}")
     public ResponseEntity<StudyResponseDTO> deleteStudy(@PathVariable Long id) {
         StudyEntity deletedStudy = studyService.showStudy(id);
+        StudyResponseDTO studyResponseDTO = modelMapper.map(deletedStudy, StudyResponseDTO.class);
 
         studyService.deleteStudy(id);
 
-        return ResponseEntity.ok(modelMapper.map(deletedStudy, StudyResponseDTO.class));
+        return ResponseEntity.ok(studyResponseDTO);
     }
 
 }

--- a/src/main/java/com/example/comitserver/entity/StudyEntity.java
+++ b/src/main/java/com/example/comitserver/entity/StudyEntity.java
@@ -29,7 +29,7 @@ public class StudyEntity extends BaseTimeEntity{
     @Column(nullable = false)
     private String imageSrc;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER) // FetchType이 LAZY면 문제가 발생
     @JoinColumn(name = "user_id")
     private UserEntity mentor;
 

--- a/src/main/java/com/example/comitserver/service/StudyService.java
+++ b/src/main/java/com/example/comitserver/service/StudyService.java
@@ -2,7 +2,6 @@ package com.example.comitserver.service;
 
 import com.example.comitserver.dto.CustomUserDetails;
 import com.example.comitserver.dto.StudyRequestDTO;
-import com.example.comitserver.dto.StudyResponseDTO;
 import com.example.comitserver.entity.StudyEntity;
 import com.example.comitserver.repository.StudyRepository;
 import com.example.comitserver.repository.UserRepository;


### PR DESCRIPTION
### Description

<!-- Please explain what this PR is solving -->
- 스터디 엔티티의 mentor 필드의 fetchType을 LAZY에서 EAGER로 변경
- 스터디 컨트롤러의 deleteStudy 코드 순서 일부를 staus 500이 뜨지 않게 변경
<!-- Please close the issue (Closes #<issue number>) -->
Closes #18 
### Additional context

<!-- Please specify the point to focus during code review -->
- fetchType이 LAZY면 문제가 발생하는 이유들
  - FetchType.LAZY는 실제 데이터 대신 프록시 객체를 반환하며, 해당 프록시 객체를 사용하려는 시점에 데이터베이스에서 데이터를 조회합니다. 그러나 프록시가 초기화되기 전에 프록시 객체에 접근하면 데이터가 로딩되지 않으면서 오류가 발생할 수 있습니다.
  - Spring Security는 보안 설정에 따라 객체에 대한 접근 권한을 결정합니다. FetchType.LAZY일 때 실제 데이터를 가져오는 시점이 달라질 수 있으며, 이로 인해 권한이 제대로 적용되지 않는 경우가 생길 수 있습니다.
  - FetchType.LAZY는 지연 로딩된 필드를 프록시로 감싸서 전달하는데, 프록시 객체는 직렬화가 제대로 되지 않을 수 있습니다. 특히, 컨트롤러에서 엔티티를 직접 반환하거나 JSON으로 변환할 때 문제가 발생할 수 있으며 403 오류로 해석될 수 있습니다. 이는 주로 Jackson과 같은 JSON 변환 라이브러리에서 발생하며, 직접적으로 Forbidden 오류를 발생시킬 수 있습니다.
- delete시 status 500이 뜬 이유와 해결 방법
  - 원래는 deletedStudy에 삭제할 스터디 엔티티 객체를 저장하고 스터디 엔티티를 삭제한 뒤 deletedStudy를 DTO로 매핑했습니다. 근데 deletedStudy에 저장해두더라도 같은 transaction 내에서는 deleteStudy(id)를 함으로써 이미 삭제된 상태로 인식됩니다. 일종의 shallow copy입니다. 하지만 스터디 엔티티를 삭제하기 전에 DTO로 매핑을 먼저 해서 DTO로 저장을 해두면 deep copy로 객체 값을 참조하는 것이 아닌 복사하여 독립된 객체가 되어 deleteStudy(id)와 연관이 없게 됩니다.