### PR TITLE
feat: add identification before put and delete a study

### DIFF
--- a/src/main/java/com/example/comitserver/controller/StudyController.java
+++ b/src/main/java/com/example/comitserver/controller/StudyController.java
@@ -4,9 +4,11 @@ import com.example.comitserver.dto.CustomUserDetails;
 import com.example.comitserver.dto.StudyRequestDTO;
 import com.example.comitserver.dto.StudyResponseDTO;
 import com.example.comitserver.entity.StudyEntity;
+import com.example.comitserver.repository.StudyRepository;
 import com.example.comitserver.service.StudyService;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -58,24 +60,30 @@ public class StudyController {
     }
 
     @PutMapping("/studies/{id}")
-    public ResponseEntity<StudyResponseDTO> putStudy(@PathVariable Long id, @RequestBody StudyRequestDTO studyRequestDTO) {
-        StudyEntity updatedStudy = studyService.updateStudy(id, studyRequestDTO);
+    public ResponseEntity<StudyResponseDTO> putStudy(@PathVariable Long id, @RequestBody StudyRequestDTO studyRequestDTO, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        if (studyService.identification(id, customUserDetails)) {
+            StudyEntity updatedStudy = studyService.updateStudy(id, studyRequestDTO);
 
-        if (updatedStudy == null) {
-            return ResponseEntity.notFound().build();
+            if (updatedStudy == null) {
+                return ResponseEntity.notFound().build();
+            }
+
+            return ResponseEntity.ok(modelMapper.map(updatedStudy, StudyResponseDTO.class));
         }
-
-        return ResponseEntity.ok(modelMapper.map(updatedStudy, StudyResponseDTO.class));
+        else return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
     }
 
     @DeleteMapping("/studies/{id}")
-    public ResponseEntity<StudyResponseDTO> deleteStudy(@PathVariable Long id) {
-        StudyEntity deletedStudy = studyService.showStudy(id);
-        StudyResponseDTO studyResponseDTO = modelMapper.map(deletedStudy, StudyResponseDTO.class);
+    public ResponseEntity<StudyResponseDTO> deleteStudy(@PathVariable Long id, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        if(studyService.identification(id, customUserDetails)) {
+            StudyEntity deletedStudy = studyService.showStudy(id);
+            StudyResponseDTO studyResponseDTO = modelMapper.map(deletedStudy, StudyResponseDTO.class);
 
-        studyService.deleteStudy(id);
+            studyService.deleteStudy(id);
 
-        return ResponseEntity.ok(studyResponseDTO);
+            return ResponseEntity.ok(studyResponseDTO);
+        }
+        else return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
     }
 
 }

--- a/src/main/java/com/example/comitserver/service/StudyService.java
+++ b/src/main/java/com/example/comitserver/service/StudyService.java
@@ -3,6 +3,7 @@ package com.example.comitserver.service;
 import com.example.comitserver.dto.CustomUserDetails;
 import com.example.comitserver.dto.StudyRequestDTO;
 import com.example.comitserver.entity.StudyEntity;
+import com.example.comitserver.entity.UserEntity;
 import com.example.comitserver.repository.StudyRepository;
 import com.example.comitserver.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -10,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 @Service
 @Transactional
@@ -76,5 +78,12 @@ public class StudyService {
     public void deleteStudy(Long id) {
         StudyEntity deletingStudy = showStudy(id);
         studyRepository.delete(deletingStudy);
+    }
+
+    public Boolean identification(Long id, CustomUserDetails customUserDetails) {
+        StudyEntity study = showStudy(id);
+        Long mentorId = study.getMentor().getId();
+        Long requesterId = customUserDetails.getUserId();
+        return Objects.equals(requesterId, mentorId);
     }
 }


### PR DESCRIPTION
### Description

<!-- Please explain what this PR is solving -->
- 스터디 수정 삭제시 요청이 날라오는 헤더 속 token의 유저id와 스터디 멘토 유저id가 같아야만 동작하도록 함. 다르면 403 status 응답
<!-- Please close the issue (Closes #<issue number>) -->
Closes #14 
### Additional context

<!-- Please specify the point to focus during code review -->
