### PR TITLE
chore: unified error type

### DIFF
--- a/src/main/java/com/example/comitserver/controller/JoinController.java
+++ b/src/main/java/com/example/comitserver/controller/JoinController.java
@@ -46,7 +46,7 @@ public class JoinController {
 
     @ExceptionHandler(DuplicateResourceException.class)
     public ResponseEntity<?> handleDuplicateResourceException(DuplicateResourceException ex, HttpServletRequest request) {
-        String endpoint = extractEndpoint(request.getRequestURI());
+        String endpoint = ResponseUtil.extractEndpoint(request.getRequestURI());
         return ResponseUtil.createErrorResponse(
                 HttpStatus.CONFLICT,
                 endpoint + "/duplicate_resource",
@@ -62,26 +62,12 @@ public class JoinController {
                 .map(DefaultMessageSourceResolvable::getDefaultMessage)
                 .orElse("Validation error");
 
-        String endpoint = extractEndpoint(request.getRequestURI());
+        String endpoint = ResponseUtil.extractEndpoint(request.getRequestURI());
 
         return ResponseUtil.createErrorResponse(
                 HttpStatus.BAD_REQUEST,
                 endpoint + "/validation_failed",
                 errorMessage
         );
-    }
-
-    // WebRequest에서 엔드포인트 정보를 추출하는 메서드
-    private String extractEndpoint(String uri) {
-        // "api/"로 시작하면 이를 제거
-        if (uri.startsWith("/api/")) {
-            uri = uri.substring(5); // "api/"를 제거
-        }
-
-        // Path Variable 부분 제거
-        uri = uri.replaceAll("/\\d+", "")  // 숫자로 된 ID 제거
-                .replaceAll("/\\{[^/]+\\}", ""); // {}로 감싸진 Path Variable 제거
-
-        return uri;
     }
 }

--- a/src/main/java/com/example/comitserver/controller/ReissueController.java
+++ b/src/main/java/com/example/comitserver/controller/ReissueController.java
@@ -23,7 +23,7 @@ public class ReissueController {
 
     @PostMapping("/reissue")
     public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
-        String endpoint = extractEndpoint(request.getRequestURI());
+        String endpoint = ResponseUtil.extractEndpoint(request.getRequestURI());
 
         String refresh = reissueService.getRefreshTokenFromCookies(request);
 
@@ -69,19 +69,5 @@ public class ReissueController {
         response.addCookie(JWTUtil.createCookie("refresh", newRefresh));
 
         return ResponseUtil.createSuccessResponse(null, HttpStatus.CREATED);
-    }
-
-    // WebRequest에서 엔드포인트 정보를 추출하는 메서드
-    private String extractEndpoint(String uri) {
-        // "api/"로 시작하면 이를 제거
-        if (uri.startsWith("/api/")) {
-            uri = uri.substring(5); // "api/"를 제거
-        }
-
-        // Path Variable 부분 제거
-        uri = uri.replaceAll("/\\d+", "")  // 숫자로 된 ID 제거
-                .replaceAll("/\\{[^/]+\\}", ""); // {}로 감싸진 Path Variable 제거
-
-        return uri;
     }
 }

--- a/src/main/java/com/example/comitserver/controller/UserAdminController.java
+++ b/src/main/java/com/example/comitserver/controller/UserAdminController.java
@@ -3,6 +3,9 @@ package com.example.comitserver.controller;
 import com.example.comitserver.entity.Role;
 import com.example.comitserver.entity.UserEntity;
 import com.example.comitserver.service.UserAdminService;
+import com.example.comitserver.utils.ResponseUtil;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,46 +22,53 @@ public class UserAdminController {
     }
 
     @GetMapping("/users")
-    public List<UserEntity> getAllUsers(@RequestParam(required = false) Boolean isStaff,
-                                        @RequestParam(required = false) Role role) {
+    public ResponseEntity<?> getAllUsers(@RequestParam(required = false) Boolean isStaff,
+                                         @RequestParam(required = false) Role role) {
+        List<UserEntity> users;
+
         if (isStaff != null && role != null) {
-            return userAdminService.getUsersByRoleAndIsStaff(role, isStaff);
+            users = userAdminService.getUsersByRoleAndIsStaff(role, isStaff);
         } else if (isStaff != null) {
-            return userAdminService.getUsersByIsStaff(isStaff);
+            users = userAdminService.getUsersByIsStaff(isStaff);
         } else if (role != null) {
-            return userAdminService.getUsersByRole(role);
+            users = userAdminService.getUsersByRole(role);
+        } else {
+            users = userAdminService.getAllUsers();
         }
-        return userAdminService.getAllUsers();
+
+        return ResponseUtil.createSuccessResponse(users, HttpStatus.OK);
     }
 
-
     @GetMapping("/users/{id}")
-    public UserEntity getUserById(@PathVariable Long id) {
-        return userAdminService.getUserById(id);
+    public ResponseEntity<?> getUserById(@PathVariable Long id) {
+        UserEntity user = userAdminService.getUserById(id);
+        return ResponseUtil.createSuccessResponse(user, HttpStatus.OK);
     }
 
     @PatchMapping("/users/{id}/role")
-    public void updateUserRole(@PathVariable Long id, @RequestBody Map<String, String> requestBody) {
+    public ResponseEntity<?> updateUserRole(@PathVariable Long id, @RequestBody Map<String, String> requestBody) {
         try {
             Role role = Role.valueOf(requestBody.get("role"));
             userAdminService.updateUserRole(id, role);
+            return ResponseUtil.createSuccessResponse(null, HttpStatus.NO_CONTENT);
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("Invalid role value provided: " + requestBody.get("role"));
+            return ResponseUtil.createErrorResponse(HttpStatus.BAD_REQUEST, "Invalid Role", "Invalid role value provided: " + requestBody.get("role"));
         }
     }
 
     @PatchMapping("/users/{id}/isStaff")
-    public void updateUserIsStaff(@PathVariable Long id, @RequestBody Map<String, Boolean> requestBody) {
+    public ResponseEntity<?> updateUserIsStaff(@PathVariable Long id, @RequestBody Map<String, Boolean> requestBody) {
         try {
             Boolean isStaff = requestBody.get("isStaff");
 
             if (isStaff == null) {
-                throw new IllegalArgumentException("isStaff value must be provided and must be either true or false.");
+                return ResponseUtil.createErrorResponse(HttpStatus.BAD_REQUEST, "Invalid isStaff", "isStaff value must be provided and must be either true or false.");
             }
 
             userAdminService.updateUserIsStaff(id, isStaff);
+            return ResponseUtil.createSuccessResponse(null, HttpStatus.NO_CONTENT);
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("Invalid isStaff value provided: " + requestBody.get("isStaff"));
+            return ResponseUtil.createErrorResponse(HttpStatus.BAD_REQUEST, "Invalid isStaff", "Invalid isStaff value provided: " + requestBody.get("isStaff"));
         }
     }
 }

--- a/src/main/java/com/example/comitserver/controller/UserController.java
+++ b/src/main/java/com/example/comitserver/controller/UserController.java
@@ -4,8 +4,11 @@ import com.example.comitserver.dto.CustomUserDetails;
 import com.example.comitserver.dto.UserDTO;
 import com.example.comitserver.entity.UserEntity;
 import com.example.comitserver.service.UserService;
+import com.example.comitserver.utils.ResponseUtil;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
@@ -24,31 +27,44 @@ public class UserController {
     }
 
     @GetMapping("/users")
-    public List<UserEntity> getAllStaffProfiles(@RequestParam(required = false) Boolean isStaff,
-                                                @AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity<?> getAllStaffProfiles(@RequestParam(required = false) Boolean isStaff,
+                                                 @AuthenticationPrincipal UserDetails userDetails) {
         if (isStaff != null) {
-            return userService.getAllUsersByStaffStatus(isStaff);
+            List<UserEntity> users = userService.getAllUsersByStaffStatus(isStaff);
+            return ResponseUtil.createSuccessResponse(users, HttpStatus.OK);
         }
         Long userId = ((CustomUserDetails) userDetails).getUserId();
-        return List.of(userService.getCurrentUserProfile(userId));
+        UserEntity userProfile = userService.getCurrentUserProfile(userId);
+        return ResponseUtil.createSuccessResponse(userProfile, HttpStatus.OK);
     }
 
     @GetMapping("/users/profile")
-    public UserEntity getUserProfile(@AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity<?> getUserProfile(@AuthenticationPrincipal UserDetails userDetails) {
         Long userId = ((CustomUserDetails) userDetails).getUserId();
-        return userService.getUserProfile(userId);
+        UserEntity userProfile = userService.getUserProfile(userId);
+        return ResponseUtil.createSuccessResponse(userProfile, HttpStatus.OK);
     }
 
-    // put->patch 변경
+    // 업데이트 후 사용자 정보를 반환(200) or 반환하지 않은(204) 중 선택 가능
     @PatchMapping("/users/profile")
-    public void updateUserProfile(@AuthenticationPrincipal UserDetails userDetails, @RequestBody @Valid UserDTO userDTO) {
+    public ResponseEntity<?> updateUserProfile(@AuthenticationPrincipal UserDetails userDetails, @RequestBody @Valid UserDTO userDTO) {
         Long userId = ((CustomUserDetails) userDetails).getUserId();
         userService.updateUserProfile(userId, userDTO);
+        // 업데이트된 사용자 정보를 반환할 수 있음
+        UserEntity updatedProfile = userService.getUserProfile(userId);
+        return ResponseUtil.createSuccessResponse(updatedProfile, HttpStatus.OK);
     }
+//    @PatchMapping("/users/profile")
+//    public ResponseEntity<?> updateUserProfile(@AuthenticationPrincipal UserDetails userDetails, @RequestBody @Valid UserDTO userDTO) {
+//        Long userId = ((CustomUserDetails) userDetails).getUserId();
+//        userService.updateUserProfile(userId, userDTO);
+//        return ResponseUtil.createSuccessResponse(null, HttpStatus.NO_CONTENT);
+//    }
 
     @DeleteMapping("/users/profile")
-    public void deleteUser(@AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity<?> deleteUser(@AuthenticationPrincipal UserDetails userDetails) {
         Long userId = ((CustomUserDetails) userDetails).getUserId();
         userService.deleteUser(userId);
+        return ResponseUtil.createSuccessResponse(null, HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/example/comitserver/dto/UserDTO.java
+++ b/src/main/java/com/example/comitserver/dto/UserDTO.java
@@ -8,7 +8,7 @@ import lombok.Data;
 
 @Data
 public class UserDTO {
-
+    // field validity check (임시)
     @Size(min = 3, max = 20, message = "Username must be between 3 and 20 characters.")
     private String username;
 

--- a/src/main/java/com/example/comitserver/jwt/JWTFilter.java
+++ b/src/main/java/com/example/comitserver/jwt/JWTFilter.java
@@ -39,7 +39,7 @@ public class JWTFilter extends OncePerRequestFilter {
         String accessToken = authorizationHeader.substring(7);
 
         // URI에서 엔드포인트 추출
-        String endpoint = extractEndpoint(request.getRequestURI());
+        String endpoint = ResponseUtil.extractEndpoint(request.getRequestURI());
 
         // 토큰 만료 여부 확인, 만료 시 다음 필터로 넘기지 않음
         try {
@@ -77,19 +77,5 @@ public class JWTFilter extends OncePerRequestFilter {
         SecurityContextHolder.getContext().setAuthentication(authToken);
 
         filterChain.doFilter(request, response);
-    }
-
-    // WebRequest에서 엔드포인트 정보를 추출하는 메서드
-    private String extractEndpoint(String uri) {
-        // "api/"로 시작하면 이를 제거
-        if (uri.startsWith("/api/")) {
-            uri = uri.substring(5); // "api/"를 제거
-        }
-
-        // Path Variable 부분 제거
-        uri = uri.replaceAll("/\\d+", "")  // 숫자로 된 ID 제거
-                .replaceAll("/\\{[^/]+\\}", ""); // {}로 감싸진 Path Variable 제거
-
-        return uri;
     }
 }

--- a/src/main/java/com/example/comitserver/jwt/JWTFilter.java
+++ b/src/main/java/com/example/comitserver/jwt/JWTFilter.java
@@ -38,35 +38,38 @@ public class JWTFilter extends OncePerRequestFilter {
         // Bearer 이후의 토큰 부분만 추출
         String accessToken = authorizationHeader.substring(7);
 
-        // 토큰 만료 여부 확인, 만료시 다음 필터로 넘기지 않음
+        // URI에서 엔드포인트 추출
+        String endpoint = extractEndpoint(request.getRequestURI());
+
+        // 토큰 만료 여부 확인, 만료 시 다음 필터로 넘기지 않음
         try {
             jwtUtil.isExpired(accessToken);
         } catch (ExpiredJwtException e) {
-            ResponseUtil.writeErrorResponse(response, HttpStatus.UNAUTHORIZED, "Unauthorized", "Access token expired");
+            ResponseUtil.writeErrorResponse(response, HttpStatus.UNAUTHORIZED, endpoint + "/token_expired", "Access token expired");
             return;
         } catch (JwtException e) {
-            ResponseUtil.writeErrorResponse(response, HttpStatus.UNAUTHORIZED, "Unauthorized", "Invalid JWT token");
+            ResponseUtil.writeErrorResponse(response, HttpStatus.UNAUTHORIZED, endpoint + "/invalid_token", "Invalid JWT token");
             return;
         }
 
-        // 토큰이 access인지 확인 (발급시 페이로드에 명시)
+        // 토큰이 access인지 확인 (발급 시 페이로드에 명시)
         String category = jwtUtil.getCategory(accessToken);
         if (!category.equals("access")) {
-            ResponseUtil.writeErrorResponse(response, HttpStatus.UNAUTHORIZED, "Unauthorized", "Invalid access token");
+            ResponseUtil.writeErrorResponse(response, HttpStatus.UNAUTHORIZED, endpoint + "/invalid_access_token", "Invalid access token");
             return;
         }
 
         Long userId = jwtUtil.getUserId(accessToken);
 
         if (userId == null) {
-            ResponseUtil.writeErrorResponse(response, HttpStatus.UNAUTHORIZED, "Unauthorized", "User ID not found in token");
+            ResponseUtil.writeErrorResponse(response, HttpStatus.UNAUTHORIZED, endpoint + "/user_id_not_found", "User ID not found in token");
             return;
         }
 
         UserDetails userDetails = customUserDetailsService.loadUserById(userId);
 
         if (userDetails == null) {
-            ResponseUtil.writeErrorResponse(response, HttpStatus.UNAUTHORIZED, "Unauthorized", "User not found");
+            ResponseUtil.writeErrorResponse(response, HttpStatus.UNAUTHORIZED, endpoint + "/user_not_found", "User not found");
             return;
         }
 
@@ -74,5 +77,19 @@ public class JWTFilter extends OncePerRequestFilter {
         SecurityContextHolder.getContext().setAuthentication(authToken);
 
         filterChain.doFilter(request, response);
+    }
+
+    // WebRequest에서 엔드포인트 정보를 추출하는 메서드
+    private String extractEndpoint(String uri) {
+        // "api/"로 시작하면 이를 제거
+        if (uri.startsWith("/api/")) {
+            uri = uri.substring(5); // "api/"를 제거
+        }
+
+        // Path Variable 부분 제거
+        uri = uri.replaceAll("/\\d+", "")  // 숫자로 된 ID 제거
+                .replaceAll("/\\{[^/]+\\}", ""); // {}로 감싸진 Path Variable 제거
+
+        return uri;
     }
 }

--- a/src/main/java/com/example/comitserver/jwt/LoginFilter.java
+++ b/src/main/java/com/example/comitserver/jwt/LoginFilter.java
@@ -82,7 +82,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     @Override
     protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException {
-        String endpoint = extractEndpoint(request.getRequestURI());
+        String endpoint = ResponseUtil.extractEndpoint(request.getRequestURI());
 
         if (failed instanceof BadCredentialsException) {
             ResponseUtil.writeErrorResponse(
@@ -111,18 +111,5 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         refreshEntity.setExpiration(date.toString());
 
         refreshRepository.save(refreshEntity);
-    }
-
-    // 엔드포인트 정보를 추출하는 메서드
-    private String extractEndpoint(String uri) {
-        if (uri.startsWith("/api/")) {
-            uri = uri.substring(5); // "api/"를 제거
-        }
-
-        // Path Variable 부분 제거
-        uri = uri.replaceAll("/\\d+", "")  // 숫자로 된 ID 제거
-                .replaceAll("/\\{[^/]+\\}", ""); // {}로 감싸진 Path Variable 제거
-
-        return uri;
     }
 }

--- a/src/main/java/com/example/comitserver/service/UserAdminService.java
+++ b/src/main/java/com/example/comitserver/service/UserAdminService.java
@@ -36,13 +36,11 @@ public class UserAdminService {
 
     public UserEntity getUserById(Long id) {
         return userRepository.findById(id)
-//                .orElseThrow(() -> new UsernameNotFoundException("User not found with id: " + id));
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + id));
     }
 
     public void updateUserRole(Long id, Role role) {
         UserEntity user = userRepository.findById(id)
-//                .orElseThrow(() -> new UsernameNotFoundException("User not found with id: " + id));
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + id));
         user.setRole(role);
         userRepository.save(user);
@@ -50,7 +48,6 @@ public class UserAdminService {
 
     public void updateUserIsStaff(Long id, Boolean isStaff) {
         UserEntity user = userRepository.findById(id)
-//                .orElseThrow(() -> new UsernameNotFoundException("User not found with id: " + id));
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + id));
         user.setIsStaff(isStaff);
         userRepository.save(user);

--- a/src/main/java/com/example/comitserver/service/UserService.java
+++ b/src/main/java/com/example/comitserver/service/UserService.java
@@ -3,6 +3,7 @@ package com.example.comitserver.service;
 import com.example.comitserver.dto.UserDTO;
 import com.example.comitserver.entity.UserEntity;
 import com.example.comitserver.exception.DuplicateResourceException;
+import com.example.comitserver.exception.ResourceNotFoundException;
 import com.example.comitserver.repository.UserRepository;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,40 +28,36 @@ public class UserService {
 
     public UserEntity getCurrentUserProfile(Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found with id: " + userId));
+                .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + userId));
     }
 
     public UserEntity getUserProfile(Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found with id: " + userId));
+                .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + userId));
     }
 
     public void updateUserProfile(Long userId, @Valid UserDTO userDTO) {
         UserEntity user = userRepository.findById(userId)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found with id: " + userId));
+                .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + userId));
 
-        // 중복 체크
+        // @Valid 가 UserDto의 필드 validity check
         checkForDuplicateFields(userDTO, user);
-        // 필드별로 null 체크 후 업데이트
         updateUserFields(user, userDTO);
 
         userRepository.save(user);
     }
 
     private void checkForDuplicateFields(UserDTO userDTO, UserEntity user) {
-        // 이메일 중복 체크 (자신의 이메일은 제외)
         if (userDTO.getEmail() != null && !userDTO.getEmail().equals(user.getEmail()) &&
                 userRepository.existsByEmail(userDTO.getEmail())) {
             throw new DuplicateResourceException("Email is already in use.");
         }
 
-        // 학번 중복 체크 (자신의 학번은 제외)
         if (userDTO.getStudentId() != null && !userDTO.getStudentId().equals(user.getStudentId()) &&
                 userRepository.existsByStudentId(userDTO.getStudentId())) {
             throw new DuplicateResourceException("Student ID is already in use.");
         }
 
-        // 전화번호 중복 체크 (자신의 전화번호는 제외)
         if (userDTO.getPhoneNumber() != null && !userDTO.getPhoneNumber().equals(user.getPhoneNumber()) &&
                 userRepository.existsByPhoneNumber(userDTO.getPhoneNumber())) {
             throw new DuplicateResourceException("Phone number is already in use.");

--- a/src/main/java/com/example/comitserver/utils/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/comitserver/utils/GlobalExceptionHandler.java
@@ -3,8 +3,6 @@ package com.example.comitserver.utils;
 import com.example.comitserver.dto.ServerResponseDTO;
 import com.example.comitserver.exception.DuplicateResourceException;
 import com.example.comitserver.exception.ResourceNotFoundException;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -14,20 +12,19 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 
 import javax.naming.AuthenticationException;
-import java.nio.file.AccessDeniedException;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<ServerResponseDTO> handleResourceNotFoundException(ResourceNotFoundException ex, WebRequest request) {
-        String errorType = extractEndpoint(request) + "/resource_not_found";
+        String errorType = ResponseUtil.extractEndpoint(request) + "/resource_not_found";
         return ResponseUtil.createErrorResponse(HttpStatus.NOT_FOUND, errorType, ex.getMessage());
     }
 
     @ExceptionHandler(UsernameNotFoundException.class)
     public ResponseEntity<ServerResponseDTO> handleUsernameNotFoundException(UsernameNotFoundException ex, WebRequest request) {
-        String errorType = extractEndpoint(request) + "/user_not_found";
+        String errorType = ResponseUtil.extractEndpoint(request) + "/user_not_found";
         return ResponseUtil.createErrorResponse(HttpStatus.NOT_FOUND, errorType, ex.getMessage());
     }
 
@@ -35,73 +32,55 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ServerResponseDTO> handleValidationException(MethodArgumentNotValidException ex, WebRequest request) {
         String validationErrors = ex.getBindingResult().toString();
-        String errorType = extractEndpoint(request) + "/validation_error";
+        String errorType = ResponseUtil.extractEndpoint(request) + "/validation_error";
         return ResponseUtil.createErrorResponse(HttpStatus.BAD_REQUEST, errorType, validationErrors);
     }
 
     // Spring Security 인증 관련 예외 처리
     @ExceptionHandler(AuthenticationException.class)
     public ResponseEntity<ServerResponseDTO> handleAuthenticationException(AuthenticationException ex, WebRequest request) {
-        String errorType = extractEndpoint(request) + "/unauthorized";
+        String errorType = ResponseUtil.extractEndpoint(request) + "/unauthorized";
         return ResponseUtil.createErrorResponse(HttpStatus.UNAUTHORIZED, errorType, "Authentication failed.");
     }
 
 //    // JWT 토큰 만료 및 기타 JWT 예외 처리
 //    @ExceptionHandler(ExpiredJwtException.class)
 //    public ResponseEntity<ServerResponseDTO> handleExpiredJwtException(ExpiredJwtException ex, WebRequest request) {
-//        String errorType = extractEndpoint(request) + "/token_expired";
+//        String errorType = ResponseUtil.extractEndpoint(request) + "/token_expired";
 //        return ResponseUtil.createErrorResponse(HttpStatus.UNAUTHORIZED, errorType, "The access token has expired.");
 //    }
 //
 //    @ExceptionHandler(JwtException.class)
 //    public ResponseEntity<ServerResponseDTO> handleJwtException(JwtException ex, WebRequest request) {
-//        String errorType = extractEndpoint(request) + "/invalid_token";
+//        String errorType = ResponseUtil.extractEndpoint(request) + "/invalid_token";
 //        return ResponseUtil.createErrorResponse(HttpStatus.UNAUTHORIZED, errorType, "Invalid JWT token.");
 //    } -> jwtfilter에서 처리되는것으로 확인됨
 
     // user detail null 토큰 없을 때 예외 처리
     @ExceptionHandler(NullPointerException.class)
     public ResponseEntity<ServerResponseDTO> handleNullPointerException(NullPointerException ex, WebRequest request) {
-        String errorType = extractEndpoint(request) + "/unauthorized";
+        String errorType = ResponseUtil.extractEndpoint(request) + "/unauthorized";
         return ResponseUtil.createErrorResponse(HttpStatus.UNAUTHORIZED, errorType, "Authentication not provided.");
     }
 
     // update 할때 중복 예외 처리
     @ExceptionHandler(DuplicateResourceException.class)
     public ResponseEntity<ServerResponseDTO> handleDuplicateResourceException(DuplicateResourceException ex, WebRequest request) {
-        String errorType = extractEndpoint(request) + "/duplicate_resource";
+        String errorType = ResponseUtil.extractEndpoint(request) + "/duplicate_resource";
         return ResponseUtil.createErrorResponse(HttpStatus.CONFLICT, errorType, ex.getMessage());
     }
 
     // IllegalArgumentException 처리
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ServerResponseDTO> handleIllegalArgumentException(IllegalArgumentException ex, WebRequest request) {
-        String errorType = extractEndpoint(request) + "/bad_request";
+        String errorType = ResponseUtil.extractEndpoint(request) + "/bad_request";
         return ResponseUtil.createErrorResponse(HttpStatus.BAD_REQUEST, errorType, ex.getMessage());
     }
 
     // 기타 모든 예외 처리
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ServerResponseDTO> handleGlobalException(Exception ex, WebRequest request) {
-        String errorType = extractEndpoint(request) + "/internal_server_error";
+        String errorType = ResponseUtil.extractEndpoint(request) + "/internal_server_error";
         return ResponseUtil.createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, errorType, ex.getMessage());
-    }
-
-    // WebRequest에서 엔드포인트 정보를 추출하는 메서드
-    private String extractEndpoint(WebRequest request) {
-        String uri = request.getDescription(false)
-                .replace("uri=", "")
-                .split("\\?")[0]; // 쿼리 파라미터 제거
-
-        // "api/"로 시작하면 이를 제거
-        if (uri.startsWith("/api/")) {
-            uri = uri.substring(5); // "api/"를 제거
-        }
-
-        // Path Variable 부분 제거
-        uri = uri.replaceAll("/\\d+", "")  // 숫자로 된 ID 제거
-                .replaceAll("/\\{[^/]+\\}", ""); // {}로 감싸진 Path Variable 제거
-
-        return uri;
     }
 }

--- a/src/main/java/com/example/comitserver/utils/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/comitserver/utils/GlobalExceptionHandler.java
@@ -19,70 +19,89 @@ import java.nio.file.AccessDeniedException;
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
-    // ResourceNotFoundException 예외 처리
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<ServerResponseDTO> handleResourceNotFoundException(ResourceNotFoundException ex, WebRequest request) {
-        return ResponseUtil.createErrorResponse(HttpStatus.NOT_FOUND, "Resource Not Found", ex.getMessage());
+        String errorType = extractEndpoint(request) + "/resource_not_found";
+        return ResponseUtil.createErrorResponse(HttpStatus.NOT_FOUND, errorType, ex.getMessage());
     }
 
-    // UsernameNotFoundException 처리
     @ExceptionHandler(UsernameNotFoundException.class)
     public ResponseEntity<ServerResponseDTO> handleUsernameNotFoundException(UsernameNotFoundException ex, WebRequest request) {
-        return ResponseUtil.createErrorResponse(HttpStatus.NOT_FOUND, "User Not Found", ex.getMessage());
+        String errorType = extractEndpoint(request) + "/user_not_found";
+        return ResponseUtil.createErrorResponse(HttpStatus.NOT_FOUND, errorType, ex.getMessage());
     }
 
-    // Validation 예외 처리
+    // 필드 Validation 예외 처리
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ServerResponseDTO> handleValidationException(MethodArgumentNotValidException ex) {
+    public ResponseEntity<ServerResponseDTO> handleValidationException(MethodArgumentNotValidException ex, WebRequest request) {
         String validationErrors = ex.getBindingResult().toString();
-        return ResponseUtil.createErrorResponse(HttpStatus.BAD_REQUEST, "Validation Error", validationErrors);
+        String errorType = extractEndpoint(request) + "/validation_error";
+        return ResponseUtil.createErrorResponse(HttpStatus.BAD_REQUEST, errorType, validationErrors);
     }
 
     // Spring Security 인증 관련 예외 처리
     @ExceptionHandler(AuthenticationException.class)
     public ResponseEntity<ServerResponseDTO> handleAuthenticationException(AuthenticationException ex, WebRequest request) {
-        return ResponseUtil.createErrorResponse(HttpStatus.UNAUTHORIZED, "Unauthorized", "Authentication failed.123");
+        String errorType = extractEndpoint(request) + "/unauthorized";
+        return ResponseUtil.createErrorResponse(HttpStatus.UNAUTHORIZED, errorType, "Authentication failed.");
     }
 
-    // JWT 토큰 만료 및 기타 JWT 예외 처리
-    @ExceptionHandler(ExpiredJwtException.class)
-    public ResponseEntity<ServerResponseDTO> handleExpiredJwtException(ExpiredJwtException ex, WebRequest request) {
-        return ResponseUtil.createErrorResponse(HttpStatus.UNAUTHORIZED, "Unauthorized", "The access token has expired.123");
-    }
-
-    @ExceptionHandler(JwtException.class)
-    public ResponseEntity<ServerResponseDTO> handleJwtException(JwtException ex, WebRequest request) {
-        return ResponseUtil.createErrorResponse(HttpStatus.UNAUTHORIZED, "Unauthorized", "Invalid JWT token.123");
-    }
+//    // JWT 토큰 만료 및 기타 JWT 예외 처리
+//    @ExceptionHandler(ExpiredJwtException.class)
+//    public ResponseEntity<ServerResponseDTO> handleExpiredJwtException(ExpiredJwtException ex, WebRequest request) {
+//        String errorType = extractEndpoint(request) + "/token_expired";
+//        return ResponseUtil.createErrorResponse(HttpStatus.UNAUTHORIZED, errorType, "The access token has expired.");
+//    }
+//
+//    @ExceptionHandler(JwtException.class)
+//    public ResponseEntity<ServerResponseDTO> handleJwtException(JwtException ex, WebRequest request) {
+//        String errorType = extractEndpoint(request) + "/invalid_token";
+//        return ResponseUtil.createErrorResponse(HttpStatus.UNAUTHORIZED, errorType, "Invalid JWT token.");
+//    } -> jwtfilter에서 처리되는것으로 확인됨
 
     // user detail null 토큰 없을 때 예외 처리
     @ExceptionHandler(NullPointerException.class)
     public ResponseEntity<ServerResponseDTO> handleNullPointerException(NullPointerException ex, WebRequest request) {
-        return ResponseUtil.createErrorResponse(HttpStatus.UNAUTHORIZED, "Unauthorized", "Authentication not provided.");
+        String errorType = extractEndpoint(request) + "/unauthorized";
+        return ResponseUtil.createErrorResponse(HttpStatus.UNAUTHORIZED, errorType, "Authentication not provided.");
     }
 
     // update 할때 중복 예외 처리
     @ExceptionHandler(DuplicateResourceException.class)
-    public ResponseEntity<ServerResponseDTO> handleDuplicateResourceException(DuplicateResourceException ex) {
-        return ResponseUtil.createErrorResponse(
-                HttpStatus.CONFLICT,
-                "Duplicate Resource",
-                ex.getMessage()
-        );
+    public ResponseEntity<ServerResponseDTO> handleDuplicateResourceException(DuplicateResourceException ex, WebRequest request) {
+        String errorType = extractEndpoint(request) + "/duplicate_resource";
+        return ResponseUtil.createErrorResponse(HttpStatus.CONFLICT, errorType, ex.getMessage());
     }
 
     // IllegalArgumentException 처리
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ServerResponseDTO> handleIllegalArgumentException(IllegalArgumentException ex, WebRequest request) {
-        return ResponseUtil.createErrorResponse(HttpStatus.BAD_REQUEST, "Bad Request", ex.getMessage());
+        String errorType = extractEndpoint(request) + "/bad_request";
+        return ResponseUtil.createErrorResponse(HttpStatus.BAD_REQUEST, errorType, ex.getMessage());
     }
 
-    // 기타 모든 예외 처리 (Global Exception Handling)
+    // 기타 모든 예외 처리
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ServerResponseDTO> handleGlobalException(Exception ex, WebRequest request) {
-        return ResponseUtil.createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error", ex.getMessage());
+        String errorType = extractEndpoint(request) + "/internal_server_error";
+        return ResponseUtil.createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, errorType, ex.getMessage());
     }
 
+    // WebRequest에서 엔드포인트 정보를 추출하는 메서드
+    private String extractEndpoint(WebRequest request) {
+        String uri = request.getDescription(false)
+                .replace("uri=", "")
+                .split("\\?")[0]; // 쿼리 파라미터 제거
 
+        // "api/"로 시작하면 이를 제거
+        if (uri.startsWith("/api/")) {
+            uri = uri.substring(5); // "api/"를 제거
+        }
 
+        // Path Variable 부분 제거
+        uri = uri.replaceAll("/\\d+", "")  // 숫자로 된 ID 제거
+                .replaceAll("/\\{[^/]+\\}", ""); // {}로 감싸진 Path Variable 제거
+
+        return uri;
+    }
 }

--- a/src/main/java/com/example/comitserver/utils/ResponseUtil.java
+++ b/src/main/java/com/example/comitserver/utils/ResponseUtil.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.WebRequest;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -89,5 +90,37 @@ public class ResponseUtil {
         try (PrintWriter out = response.getWriter()) {
             out.write(objectMapper.writeValueAsString(responseBody));
         }
+    }
+
+    // URI에서 엔드포인트 정보를 추출하는 메서드
+    public static String extractEndpoint(String uri) {
+        // "api/"로 시작하면 이를 제거
+        if (uri.startsWith("/api/")) {
+            uri = uri.substring(5); // "api/"를 제거
+        }
+
+        // Path Variable 부분 제거
+        uri = uri.replaceAll("/\\d+", "")  // 숫자로 된 ID 제거
+                .replaceAll("/\\{[^/]+\\}", ""); // {}로 감싸진 Path Variable 제거
+
+        return uri;
+    }
+
+    // WebRequest에서 엔드포인트 정보를 추출하는 메서드
+    public static String extractEndpoint(WebRequest request) {
+        String uri = request.getDescription(false)
+                .replace("uri=", "")
+                .split("\\?")[0]; // 쿼리 파라미터 제거
+
+        // "api/"로 시작하면 이를 제거
+        if (uri.startsWith("/api/")) {
+            uri = uri.substring(5); // "api/"를 제거
+        }
+
+        // Path Variable 부분 제거
+        uri = uri.replaceAll("/\\d+", "")  // 숫자로 된 ID 제거
+                .replaceAll("/\\{[^/]+\\}", ""); // {}로 감싸진 Path Variable 제거
+
+        return uri;
     }
 }


### PR DESCRIPTION
### Description

UserController뿐 아니라 JwtFilter, LoginFilter, JoinController, ReissueController에서 모두 엔드포인트 명시하는 에러 타입으로 통일했습니다. (extractEndpoint 함수 통해 api/와 path variable(ex. {id}) 제외)

### Additional context

하지만 아직 UserController response에서 여전히 패스워드 제공하고 있어 새로 이슈 파서 수정하겠습니다. 

at/rt 각각 2분 4분으로 설정했습니다.
