### PR TITLE
fix isStaff error & refactor admin deleteUserbyId

### DIFF
--- a/src/main/java/com/example/comitserver/controller/UserAdminController.java
+++ b/src/main/java/com/example/comitserver/controller/UserAdminController.java
@@ -3,6 +3,7 @@ package com.example.comitserver.controller;
 import com.example.comitserver.dto.AdminUserResponseDTO;
 import com.example.comitserver.entity.Role;
 import com.example.comitserver.entity.UserEntity;
+import com.example.comitserver.exception.ResourceNotFoundException;
 import com.example.comitserver.service.UserAdminService;
 import com.example.comitserver.utils.ResponseUtil;
 import org.modelmapper.ModelMapper;
@@ -74,22 +75,36 @@ public class UserAdminController {
         return ResponseUtil.createSuccessResponse(null, HttpStatus.NO_CONTENT);
     }
 
+//    @DeleteMapping("/users/{id}")
+//    public ResponseEntity<?> deleteUserById(@PathVariable Long id) {
+//        try {
+//            UserEntity user = userAdminService.getUserById(id);
+//            boolean deleted = userAdminService.deleteUserById(id);
+//
+//            if (deleted) {
+//                AdminUserResponseDTO userDTO = modelMapper.map(user, AdminUserResponseDTO.class);
+//                return ResponseUtil.createSuccessResponse(userDTO, HttpStatus.OK);
+//            } else {
+//                return ResponseUtil.createErrorResponse(HttpStatus.NOT_FOUND, "User Not Found", "No user found with id: " + id);
+//            }
+//        } catch (NoSuchElementException e) {
+//            return ResponseUtil.createErrorResponse(HttpStatus.NOT_FOUND, "User Not Found", "No user found with id: " + id);
+//        } catch (Exception e) {
+//            return ResponseUtil.createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Deletion Failed", "An error occurred while attempting to delete the user.");
+//        }
+//    }
     @DeleteMapping("/users/{id}")
     public ResponseEntity<?> deleteUserById(@PathVariable Long id) {
-        try {
-            UserEntity user = userAdminService.getUserById(id);
-            boolean deleted = userAdminService.deleteUserById(id);
+        UserEntity user = userAdminService.getUserById(id); // 존재하지 않을 때 이미 GlobalExceptionHandler에서 처리됨
+        boolean deleted = userAdminService.deleteUserById(id);
 
-            if (deleted) {
-                AdminUserResponseDTO userDTO = modelMapper.map(user, AdminUserResponseDTO.class);
-                return ResponseUtil.createSuccessResponse(userDTO, HttpStatus.OK);
-            } else {
-                return ResponseUtil.createErrorResponse(HttpStatus.NOT_FOUND, "User Not Found", "No user found with id: " + id);
-            }
-        } catch (NoSuchElementException e) {
-            return ResponseUtil.createErrorResponse(HttpStatus.NOT_FOUND, "User Not Found", "No user found with id: " + id);
-        } catch (Exception e) {
-            return ResponseUtil.createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Deletion Failed", "An error occurred while attempting to delete the user.");
+        // 삭제 실패 시, Internal Server Error 응답 반환
+        if (!deleted) {
+            return ResponseUtil.createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Deletion Failed", "Failed to delete user with id: " + id);
+        } else {
+            // 삭제 성공 시, OK 응답 반환
+            AdminUserResponseDTO userDTO = modelMapper.map(user, AdminUserResponseDTO.class);
+            return ResponseUtil.createSuccessResponse(userDTO, HttpStatus.OK);
         }
     }
 }

--- a/src/main/java/com/example/comitserver/controller/UserAdminController.java
+++ b/src/main/java/com/example/comitserver/controller/UserAdminController.java
@@ -55,29 +55,23 @@ public class UserAdminController {
 
     @PatchMapping("/users/{id}/role")
     public ResponseEntity<?> updateUserRole(@PathVariable Long id, @RequestBody Map<String, String> requestBody) {
-        try {
-            Role role = Role.valueOf(requestBody.get("role"));
-            userAdminService.updateUserRole(id, role);
-            return ResponseUtil.createSuccessResponse(null, HttpStatus.NO_CONTENT);
-        } catch (IllegalArgumentException e) {
-            return ResponseUtil.createErrorResponse(HttpStatus.BAD_REQUEST, "Invalid Role", "Invalid role value provided: " + requestBody.get("role"));
-        }
+        Role role = Role.valueOf(requestBody.get("role"));
+        userAdminService.updateUserRole(id, role);
+        return ResponseUtil.createSuccessResponse(null, HttpStatus.NO_CONTENT);
     }
 
     @PatchMapping("/users/{id}/isStaff")
     public ResponseEntity<?> updateUserIsStaff(@PathVariable Long id, @RequestBody Map<String, Boolean> requestBody) {
-        try {
-            Boolean isStaff = requestBody.get("isStaff");
+        Boolean isStaff = requestBody.get("isStaff");
 
-            if (isStaff == null) {
-                return ResponseUtil.createErrorResponse(HttpStatus.BAD_REQUEST, "Invalid isStaff", "isStaff value must be provided and must be either true or false.");
-            }
-
-            userAdminService.updateUserIsStaff(id, isStaff);
-            return ResponseUtil.createSuccessResponse(null, HttpStatus.NO_CONTENT);
-        } catch (IllegalArgumentException e) {
-            return ResponseUtil.createErrorResponse(HttpStatus.BAD_REQUEST, "Invalid isStaff", "Invalid isStaff value provided: " + requestBody.get("isStaff"));
+        // 엔티티에서 nullable하지 않아 발생할 수 있는 500 Internal Server Error를 방지하고
+        // 클라이언트에게 400 Bad Request 응답을 반환하도록 설정
+        if (isStaff == null) {
+            throw new IllegalArgumentException("isStaff value must be provided and must be either true or false.");
         }
+
+        userAdminService.updateUserIsStaff(id, isStaff);
+        return ResponseUtil.createSuccessResponse(null, HttpStatus.NO_CONTENT);
     }
 
     @DeleteMapping("/users/{id}")

--- a/src/main/java/com/example/comitserver/controller/UserAdminController.java
+++ b/src/main/java/com/example/comitserver/controller/UserAdminController.java
@@ -75,24 +75,6 @@ public class UserAdminController {
         return ResponseUtil.createSuccessResponse(null, HttpStatus.NO_CONTENT);
     }
 
-//    @DeleteMapping("/users/{id}")
-//    public ResponseEntity<?> deleteUserById(@PathVariable Long id) {
-//        try {
-//            UserEntity user = userAdminService.getUserById(id);
-//            boolean deleted = userAdminService.deleteUserById(id);
-//
-//            if (deleted) {
-//                AdminUserResponseDTO userDTO = modelMapper.map(user, AdminUserResponseDTO.class);
-//                return ResponseUtil.createSuccessResponse(userDTO, HttpStatus.OK);
-//            } else {
-//                return ResponseUtil.createErrorResponse(HttpStatus.NOT_FOUND, "User Not Found", "No user found with id: " + id);
-//            }
-//        } catch (NoSuchElementException e) {
-//            return ResponseUtil.createErrorResponse(HttpStatus.NOT_FOUND, "User Not Found", "No user found with id: " + id);
-//        } catch (Exception e) {
-//            return ResponseUtil.createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Deletion Failed", "An error occurred while attempting to delete the user.");
-//        }
-//    }
     @DeleteMapping("/users/{id}")
     public ResponseEntity<?> deleteUserById(@PathVariable Long id) {
         UserEntity user = userAdminService.getUserById(id); // 존재하지 않을 때 이미 GlobalExceptionHandler에서 처리됨

--- a/src/main/java/com/example/comitserver/service/UserService.java
+++ b/src/main/java/com/example/comitserver/service/UserService.java
@@ -90,11 +90,13 @@ public class UserService {
         }
     }
 
-    public void deleteUser(Long userId) {
-        UserEntity user = userRepository.findById(userId)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found with id: " + userId));
-
-        userRepository.delete(user);
+    public boolean deleteUser(Long userId) {
+        if (userRepository.existsById(Math.toIntExact(userId))) {
+            userRepository.deleteById(Math.toIntExact(userId));
+            return true;
+        } else {
+            return false;
+        }
     }
 
     public List<StudyEntity> getCreatedStudies(Long userId) {

--- a/src/main/java/com/example/comitserver/utils/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/comitserver/utils/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 
 import javax.naming.AuthenticationException;
+import java.util.NoSuchElementException;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {

--- a/src/main/java/com/example/comitserver/utils/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/comitserver/utils/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.example.comitserver.exception.DuplicateResourceException;
 import com.example.comitserver.exception.ResourceNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -43,24 +44,28 @@ public class GlobalExceptionHandler {
         return ResponseUtil.createErrorResponse(HttpStatus.UNAUTHORIZED, errorType, "Authentication failed.");
     }
 
-//    // JWT 토큰 만료 및 기타 JWT 예외 처리
-//    @ExceptionHandler(ExpiredJwtException.class)
-//    public ResponseEntity<ServerResponseDTO> handleExpiredJwtException(ExpiredJwtException ex, WebRequest request) {
-//        String errorType = ResponseUtil.extractEndpoint(request) + "/token_expired";
-//        return ResponseUtil.createErrorResponse(HttpStatus.UNAUTHORIZED, errorType, "The access token has expired.");
-//    }
-//
-//    @ExceptionHandler(JwtException.class)
-//    public ResponseEntity<ServerResponseDTO> handleJwtException(JwtException ex, WebRequest request) {
-//        String errorType = ResponseUtil.extractEndpoint(request) + "/invalid_token";
-//        return ResponseUtil.createErrorResponse(HttpStatus.UNAUTHORIZED, errorType, "Invalid JWT token.");
-//    } -> jwtfilter에서 처리되는것으로 확인됨
-
-    // user detail null 토큰 없을 때 예외 처리
+    // 다양한 null pointer exception 처리
     @ExceptionHandler(NullPointerException.class)
     public ResponseEntity<ServerResponseDTO> handleNullPointerException(NullPointerException ex, WebRequest request) {
-        String errorType = ResponseUtil.extractEndpoint(request) + "/unauthorized";
-        return ResponseUtil.createErrorResponse(HttpStatus.UNAUTHORIZED, errorType, "Authentication not provided.");
+        String endpoint = ResponseUtil.extractEndpoint(request);
+
+        // 기본 에러 타입과 메시지 설정
+        String errorType = endpoint + "/null_pointer_exception";
+        String errorMessage = "A null pointer exception occurred.";
+        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+
+        // 특정 시나리오에서의 커스터마이즈
+        if (endpoint.contains("/auth") || endpoint.contains("/login") || endpoint.contains("/token")) {
+            errorType = endpoint + "/unauthorized";
+            errorMessage = "Authentication not provided.";
+            status = HttpStatus.UNAUTHORIZED;
+        } else if (endpoint.contains("/users")) {
+            errorType = endpoint + "/user_error";
+            errorMessage = "A null pointer exception occurred while processing user data.";
+            status = HttpStatus.BAD_REQUEST;
+        }
+
+        return ResponseUtil.createErrorResponse(status, errorType, errorMessage);
     }
 
     // update 할때 중복 예외 처리
@@ -73,6 +78,13 @@ public class GlobalExceptionHandler {
     // IllegalArgumentException 처리
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ServerResponseDTO> handleIllegalArgumentException(IllegalArgumentException ex, WebRequest request) {
+        String errorType = ResponseUtil.extractEndpoint(request) + "/bad_request";
+        return ResponseUtil.createErrorResponse(HttpStatus.BAD_REQUEST, errorType, ex.getMessage());
+    }
+
+    // JSON 파싱 오류 등 메시지 읽기 오류 처리
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ServerResponseDTO> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex, WebRequest request) {
         String errorType = ResponseUtil.extractEndpoint(request) + "/bad_request";
         return ResponseUtil.createErrorResponse(HttpStatus.BAD_REQUEST, errorType, ex.getMessage());
     }


### PR DESCRIPTION
### Description

-updateUserIsStaff
isStaff 가 null 이거나 invalid한 값으로 주어질때 400 bad request가 뜨도록 수정했습니다. 그 과정에서 GlobalExceptionHandler에서 처리되도록 케이스를 추가했고 beare token 이 없는 경우만 처리하던 NullPointerException을 다양한 상황에 맞는 에러타입을 반환하도록 수정했습니다. 

Closes #39 

-deleteUserById
해당 id 유저가 없을때 GlobalExceptionHandler에서 이미 처리되고 있어 간소하게 리팩토링 진행했습니다. 

### Additional context

현재 admin 에서 user를 삭제할 때는 삭제 된 유저의 정보가 반환되는데 client에서 user를 삭제할 때는 아무 정보를 반환하지 않고 있습니다. 어떤 방식으로 통일하면 좋을지 논의해야 할 것 같습니다.